### PR TITLE
Display human friendly error messages.

### DIFF
--- a/lib/ClientException.php
+++ b/lib/ClientException.php
@@ -32,16 +32,13 @@ namespace Ticketmatic;
  * API Client exception
  */
 class ClientException extends \Exception {
-    public $code;
-
     /**
      * Create a new ClientException.
      *
-     * @param int $code
-     * @param string $output
+     * @param int 		$code		The error code.
+     * @param string 	$output		The error message.
      */
     public function __construct($code, $output) {
-        $this->code = $code;
-        parent::__construct("Unexpected result $code: $output");
+        parent::__construct( $output, $code);
     }
 }


### PR DESCRIPTION
The `ClientException` class always returns an error message that is made out of a string, combined with an json_encode object (the output of `curl_error()`. For example: 

```
Unexpected result 403: {"code":403,"message":"Permission denied: This API key does not have the required permissions to perform this operation, you may need to adjust the app configuration"}
```

This makes it very hard to display a user friendly error message to the end user. I think it should either be a fully formatted string or a valid JSON encoded object. In this pull request I chose for the latter. I also added the `$code` param to the construct of the native PHP `Exception` object.

You could also wonder if it's still necessary to use a custom exception class, since it doesn't add any functionality to the native `Exception` class.