### PR TITLE
allow null for birthdate

### DIFF
--- a/lib/Model/Contact.php
+++ b/lib/Model/Contact.php
@@ -301,7 +301,7 @@ class Contact implements \jsonSerializable
             $result["addresses"] = $this->addresses;
         }
         if (!is_null($this->birthdate)) {
-            $result["birthdate"] = Json::packTimestamp($this->birthdate);
+            $result["birthdate"] = !empty($this->birthdate) ? Json::packTimestamp($this->birthdate) : null;
         }
         if (!is_null($this->company)) {
             $result["company"] = strval($this->company);

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -163,9 +163,7 @@ class Request {
             $headers[] = "Expect:"; // issue with cURL when doing big size POSTs https://stackoverflow.com/questions/14158675/how-can-i-stop-curl-from-using-100-continue
             if ($this->bodycontenttype == "json") {
                 foreach ($this->body as $key => $value) {
-                    if (!is_null($value)) {
-                        $body[$key] = $value;
-                    }
+                    $body[$key] = $value;
                 }
                 $body = json_encode($body);
                 $headers[] = "Content-Type: application/json";


### PR DESCRIPTION
- Allow a null to be sent for the birth date case

Solves error where the birth date could not be removed from the user account