### PR TITLE
PHP 8.1 JsonSerialize deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*.swp
 /vendor/
 /composer.lock
+.idea

--- a/lib/Model/AccountInfo.php
+++ b/lib/Model/AccountInfo.php
@@ -141,10 +141,8 @@ class AccountInfo implements \jsonSerializable
 
     /**
      * Serialize AccountInfo to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/AccountInfo.php
+++ b/lib/Model/AccountInfo.php
@@ -141,6 +141,8 @@ class AccountInfo implements \jsonSerializable
 
     /**
      * Serialize AccountInfo to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AccountParameter.php
+++ b/lib/Model/AccountParameter.php
@@ -85,6 +85,8 @@ class AccountParameter implements \jsonSerializable
 
     /**
      * Serialize AccountParameter to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AccountParameter.php
+++ b/lib/Model/AccountParameter.php
@@ -85,10 +85,8 @@ class AccountParameter implements \jsonSerializable
 
     /**
      * Serialize AccountParameter to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->key)) {
             $result["key"] = strval($this->key);

--- a/lib/Model/AddItemsResult.php
+++ b/lib/Model/AddItemsResult.php
@@ -86,6 +86,8 @@ class AddItemsResult implements \jsonSerializable
 
     /**
      * Serialize AddItemsResult to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AddItemsResult.php
+++ b/lib/Model/AddItemsResult.php
@@ -86,10 +86,8 @@ class AddItemsResult implements \jsonSerializable
 
     /**
      * Serialize AddItemsResult to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ids)) {
             $result["ids"] = $this->ids;

--- a/lib/Model/AddPayments.php
+++ b/lib/Model/AddPayments.php
@@ -102,6 +102,8 @@ class AddPayments implements \jsonSerializable
 
     /**
      * Serialize AddPayments to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AddPayments.php
+++ b/lib/Model/AddPayments.php
@@ -102,10 +102,8 @@ class AddPayments implements \jsonSerializable
 
     /**
      * Serialize AddPayments to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/AddProducts.php
+++ b/lib/Model/AddProducts.php
@@ -78,10 +78,8 @@ class AddProducts implements \jsonSerializable
 
     /**
      * Serialize AddProducts to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->products)) {
             $result["products"] = $this->products;

--- a/lib/Model/AddProducts.php
+++ b/lib/Model/AddProducts.php
@@ -78,6 +78,8 @@ class AddProducts implements \jsonSerializable
 
     /**
      * Serialize AddProducts to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AddRefunds.php
+++ b/lib/Model/AddRefunds.php
@@ -86,6 +86,8 @@ class AddRefunds implements \jsonSerializable
 
     /**
      * Serialize AddRefunds to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AddRefunds.php
+++ b/lib/Model/AddRefunds.php
@@ -86,10 +86,8 @@ class AddRefunds implements \jsonSerializable
 
     /**
      * Serialize AddRefunds to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/AddTickets.php
+++ b/lib/Model/AddTickets.php
@@ -88,6 +88,8 @@ class AddTickets implements \jsonSerializable
 
     /**
      * Serialize AddTickets to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AddTickets.php
+++ b/lib/Model/AddTickets.php
@@ -88,10 +88,8 @@ class AddTickets implements \jsonSerializable
 
     /**
      * Serialize AddTickets to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->onlysinglerow)) {
             $result["onlysinglerow"] = (bool)$this->onlysinglerow;

--- a/lib/Model/AddVoucherCodes.php
+++ b/lib/Model/AddVoucherCodes.php
@@ -102,6 +102,8 @@ class AddVoucherCodes implements \jsonSerializable
 
     /**
      * Serialize AddVoucherCodes to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/AddVoucherCodes.php
+++ b/lib/Model/AddVoucherCodes.php
@@ -102,10 +102,8 @@ class AddVoucherCodes implements \jsonSerializable
 
     /**
      * Serialize AddVoucherCodes to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/Address.php
+++ b/lib/Model/Address.php
@@ -186,10 +186,8 @@ class Address implements \jsonSerializable
 
     /**
      * Serialize Address to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Address.php
+++ b/lib/Model/Address.php
@@ -186,6 +186,8 @@ class Address implements \jsonSerializable
 
     /**
      * Serialize Address to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Appoptin.php
+++ b/lib/Model/Appoptin.php
@@ -110,9 +110,9 @@ class Appoptin implements \jsonSerializable
     /**
      * Serialize Appoptin to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ip)) {
             $result["ip"] = strval($this->ip);

--- a/lib/Model/BatchContactOperation.php
+++ b/lib/Model/BatchContactOperation.php
@@ -95,6 +95,8 @@ class BatchContactOperation implements \jsonSerializable
 
     /**
      * Serialize BatchContactOperation to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchContactOperation.php
+++ b/lib/Model/BatchContactOperation.php
@@ -95,10 +95,8 @@ class BatchContactOperation implements \jsonSerializable
 
     /**
      * Serialize BatchContactOperation to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ids)) {
             $result["ids"] = $this->ids;

--- a/lib/Model/BatchContactParameters.php
+++ b/lib/Model/BatchContactParameters.php
@@ -111,6 +111,8 @@ class BatchContactParameters implements \jsonSerializable
 
     /**
      * Serialize BatchContactParameters to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchContactParameters.php
+++ b/lib/Model/BatchContactParameters.php
@@ -111,10 +111,8 @@ class BatchContactParameters implements \jsonSerializable
 
     /**
      * Serialize BatchContactParameters to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->name)) {
             $result["name"] = strval($this->name);

--- a/lib/Model/BatchContactUpdateField.php
+++ b/lib/Model/BatchContactUpdateField.php
@@ -95,6 +95,8 @@ class BatchContactUpdateField implements \jsonSerializable
 
     /**
      * Serialize BatchContactUpdateField to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchContactUpdateField.php
+++ b/lib/Model/BatchContactUpdateField.php
@@ -95,10 +95,8 @@ class BatchContactUpdateField implements \jsonSerializable
 
     /**
      * Serialize BatchContactUpdateField to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->key)) {
             $result["key"] = strval($this->key);

--- a/lib/Model/BatchEventOperation.php
+++ b/lib/Model/BatchEventOperation.php
@@ -95,6 +95,8 @@ class BatchEventOperation implements \jsonSerializable
 
     /**
      * Serialize BatchEventOperation to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchEventOperation.php
+++ b/lib/Model/BatchEventOperation.php
@@ -95,10 +95,8 @@ class BatchEventOperation implements \jsonSerializable
 
     /**
      * Serialize BatchEventOperation to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ids)) {
             $result["ids"] = $this->ids;

--- a/lib/Model/BatchEventParameters.php
+++ b/lib/Model/BatchEventParameters.php
@@ -78,6 +78,8 @@ class BatchEventParameters implements \jsonSerializable
 
     /**
      * Serialize BatchEventParameters to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchEventParameters.php
+++ b/lib/Model/BatchEventParameters.php
@@ -78,10 +78,8 @@ class BatchEventParameters implements \jsonSerializable
 
     /**
      * Serialize BatchEventParameters to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->updatefields)) {
             $result["updatefields"] = $this->updatefields;

--- a/lib/Model/BatchEventUpdateField.php
+++ b/lib/Model/BatchEventUpdateField.php
@@ -96,10 +96,8 @@ class BatchEventUpdateField implements \jsonSerializable
 
     /**
      * Serialize BatchEventUpdateField to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->key)) {
             $result["key"] = strval($this->key);

--- a/lib/Model/BatchEventUpdateField.php
+++ b/lib/Model/BatchEventUpdateField.php
@@ -96,6 +96,8 @@ class BatchEventUpdateField implements \jsonSerializable
 
     /**
      * Serialize BatchEventUpdateField to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchOrderOperation.php
+++ b/lib/Model/BatchOrderOperation.php
@@ -94,6 +94,8 @@ class BatchOrderOperation implements \jsonSerializable
 
     /**
      * Serialize BatchOrderOperation to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchOrderOperation.php
+++ b/lib/Model/BatchOrderOperation.php
@@ -94,10 +94,8 @@ class BatchOrderOperation implements \jsonSerializable
 
     /**
      * Serialize BatchOrderOperation to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ids)) {
             $result["ids"] = $this->ids;

--- a/lib/Model/BatchOrderParameters.php
+++ b/lib/Model/BatchOrderParameters.php
@@ -78,10 +78,8 @@ class BatchOrderParameters implements \jsonSerializable
 
     /**
      * Serialize BatchOrderParameters to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->updatefields)) {
             $result["updatefields"] = $this->updatefields;

--- a/lib/Model/BatchOrderParameters.php
+++ b/lib/Model/BatchOrderParameters.php
@@ -78,6 +78,8 @@ class BatchOrderParameters implements \jsonSerializable
 
     /**
      * Serialize BatchOrderParameters to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchOrderUpdateField.php
+++ b/lib/Model/BatchOrderUpdateField.php
@@ -95,6 +95,8 @@ class BatchOrderUpdateField implements \jsonSerializable
 
     /**
      * Serialize BatchOrderUpdateField to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchOrderUpdateField.php
+++ b/lib/Model/BatchOrderUpdateField.php
@@ -95,10 +95,8 @@ class BatchOrderUpdateField implements \jsonSerializable
 
     /**
      * Serialize BatchOrderUpdateField to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->key)) {
             $result["key"] = strval($this->key);

--- a/lib/Model/BatchResult.php
+++ b/lib/Model/BatchResult.php
@@ -85,6 +85,8 @@ class BatchResult implements \jsonSerializable
 
     /**
      * Serialize BatchResult to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchResult.php
+++ b/lib/Model/BatchResult.php
@@ -85,10 +85,8 @@ class BatchResult implements \jsonSerializable
 
     /**
      * Serialize BatchResult to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->nbrsucceeded)) {
             $result["nbrsucceeded"] = intval($this->nbrsucceeded);

--- a/lib/Model/BatchResultItem.php
+++ b/lib/Model/BatchResultItem.php
@@ -93,6 +93,8 @@ class BatchResultItem implements \jsonSerializable
 
     /**
      * Serialize BatchResultItem to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/BatchResultItem.php
+++ b/lib/Model/BatchResultItem.php
@@ -93,10 +93,8 @@ class BatchResultItem implements \jsonSerializable
 
     /**
      * Serialize BatchResultItem to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Contact.php
+++ b/lib/Model/Contact.php
@@ -359,10 +359,8 @@ class Contact implements \jsonSerializable
 
     /**
      * Serialize Contact to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Contact.php
+++ b/lib/Model/Contact.php
@@ -359,6 +359,8 @@ class Contact implements \jsonSerializable
 
     /**
      * Serialize Contact to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactAddressType.php
+++ b/lib/Model/ContactAddressType.php
@@ -129,10 +129,8 @@ class ContactAddressType implements \jsonSerializable
 
     /**
      * Serialize ContactAddressType to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactAddressType.php
+++ b/lib/Model/ContactAddressType.php
@@ -129,6 +129,8 @@ class ContactAddressType implements \jsonSerializable
 
     /**
      * Serialize ContactAddressType to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactAddressTypeQuery.php
+++ b/lib/Model/ContactAddressTypeQuery.php
@@ -99,10 +99,8 @@ class ContactAddressTypeQuery implements \jsonSerializable
 
     /**
      * Serialize ContactAddressTypeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/ContactAddressTypeQuery.php
+++ b/lib/Model/ContactAddressTypeQuery.php
@@ -99,6 +99,8 @@ class ContactAddressTypeQuery implements \jsonSerializable
 
     /**
      * Serialize ContactAddressTypeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactBatchUpdate.php
+++ b/lib/Model/ContactBatchUpdate.php
@@ -102,6 +102,8 @@ class ContactBatchUpdate implements \jsonSerializable
 
     /**
      * Serialize ContactBatchUpdate to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactBatchUpdate.php
+++ b/lib/Model/ContactBatchUpdate.php
@@ -102,10 +102,8 @@ class ContactBatchUpdate implements \jsonSerializable
 
     /**
      * Serialize ContactBatchUpdate to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->customertitleid)) {
             $result["customertitleid"] = intval($this->customertitleid);

--- a/lib/Model/ContactField.php
+++ b/lib/Model/ContactField.php
@@ -93,10 +93,8 @@ class ContactField implements \jsonSerializable
 
     /**
      * Serialize ContactField to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactField.php
+++ b/lib/Model/ContactField.php
@@ -93,6 +93,8 @@ class ContactField implements \jsonSerializable
 
     /**
      * Serialize ContactField to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactGetQuery.php
+++ b/lib/Model/ContactGetQuery.php
@@ -77,6 +77,8 @@ class ContactGetQuery implements \jsonSerializable
 
     /**
      * Serialize ContactGetQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactGetQuery.php
+++ b/lib/Model/ContactGetQuery.php
@@ -77,10 +77,8 @@ class ContactGetQuery implements \jsonSerializable
 
     /**
      * Serialize ContactGetQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->email)) {
             $result["email"] = strval($this->email);

--- a/lib/Model/ContactIdReservation.php
+++ b/lib/Model/ContactIdReservation.php
@@ -77,6 +77,8 @@ class ContactIdReservation implements \jsonSerializable
 
     /**
      * Serialize ContactIdReservation to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactIdReservation.php
+++ b/lib/Model/ContactIdReservation.php
@@ -77,10 +77,8 @@ class ContactIdReservation implements \jsonSerializable
 
     /**
      * Serialize ContactIdReservation to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactImportStatus.php
+++ b/lib/Model/ContactImportStatus.php
@@ -93,10 +93,8 @@ class ContactImportStatus implements \jsonSerializable
 
     /**
      * Serialize ContactImportStatus to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactImportStatus.php
+++ b/lib/Model/ContactImportStatus.php
@@ -93,6 +93,8 @@ class ContactImportStatus implements \jsonSerializable
 
     /**
      * Serialize ContactImportStatus to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactOptIn.php
+++ b/lib/Model/ContactOptIn.php
@@ -118,10 +118,8 @@ class ContactOptIn implements \jsonSerializable
 
     /**
      * Serialize ContactOptIn to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactOptIn.php
+++ b/lib/Model/ContactOptIn.php
@@ -118,6 +118,8 @@ class ContactOptIn implements \jsonSerializable
 
     /**
      * Serialize ContactOptIn to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactOptInInfo.php
+++ b/lib/Model/ContactOptInInfo.php
@@ -101,6 +101,8 @@ class ContactOptInInfo implements \jsonSerializable
 
     /**
      * Serialize ContactOptInInfo to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactOptInInfo.php
+++ b/lib/Model/ContactOptInInfo.php
@@ -101,10 +101,8 @@ class ContactOptInInfo implements \jsonSerializable
 
     /**
      * Serialize ContactOptInInfo to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ip)) {
             $result["ip"] = strval($this->ip);

--- a/lib/Model/ContactQuery.php
+++ b/lib/Model/ContactQuery.php
@@ -149,10 +149,8 @@ class ContactQuery implements \jsonSerializable
 
     /**
      * Serialize ContactQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/ContactQuery.php
+++ b/lib/Model/ContactQuery.php
@@ -149,6 +149,8 @@ class ContactQuery implements \jsonSerializable
 
     /**
      * Serialize ContactQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactRelationship.php
+++ b/lib/Model/ContactRelationship.php
@@ -102,9 +102,9 @@ class ContactRelationship implements \jsonSerializable
     /**
      * Serialize ContactRelationship to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactRemark.php
+++ b/lib/Model/ContactRemark.php
@@ -93,6 +93,8 @@ class ContactRemark implements \jsonSerializable
 
     /**
      * Serialize ContactRemark to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactRemark.php
+++ b/lib/Model/ContactRemark.php
@@ -93,10 +93,8 @@ class ContactRemark implements \jsonSerializable
 
     /**
      * Serialize ContactRemark to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactTitle.php
+++ b/lib/Model/ContactTitle.php
@@ -152,10 +152,8 @@ class ContactTitle implements \jsonSerializable
 
     /**
      * Serialize ContactTitle to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ContactTitle.php
+++ b/lib/Model/ContactTitle.php
@@ -152,6 +152,8 @@ class ContactTitle implements \jsonSerializable
 
     /**
      * Serialize ContactTitle to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactTitleQuery.php
+++ b/lib/Model/ContactTitleQuery.php
@@ -99,6 +99,8 @@ class ContactTitleQuery implements \jsonSerializable
 
     /**
      * Serialize ContactTitleQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ContactTitleQuery.php
+++ b/lib/Model/ContactTitleQuery.php
@@ -99,10 +99,8 @@ class ContactTitleQuery implements \jsonSerializable
 
     /**
      * Serialize ContactTitleQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/CreateOrder.php
+++ b/lib/Model/CreateOrder.php
@@ -95,6 +95,8 @@ class CreateOrder implements \jsonSerializable
 
     /**
      * Serialize CreateOrder to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CreateOrder.php
+++ b/lib/Model/CreateOrder.php
@@ -95,10 +95,8 @@ class CreateOrder implements \jsonSerializable
 
     /**
      * Serialize CreateOrder to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->events)) {
             $result["events"] = $this->events;

--- a/lib/Model/CreateProduct.php
+++ b/lib/Model/CreateProduct.php
@@ -86,6 +86,8 @@ class CreateProduct implements \jsonSerializable
 
     /**
      * Serialize CreateProduct to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CreateProduct.php
+++ b/lib/Model/CreateProduct.php
@@ -86,10 +86,8 @@ class CreateProduct implements \jsonSerializable
 
     /**
      * Serialize CreateProduct to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->productid)) {
             $result["productid"] = intval($this->productid);

--- a/lib/Model/CreateTicket.php
+++ b/lib/Model/CreateTicket.php
@@ -112,10 +112,8 @@ class CreateTicket implements \jsonSerializable
 
     /**
      * Serialize CreateTicket to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->optionbundleid)) {
             $result["optionbundleid"] = intval($this->optionbundleid);

--- a/lib/Model/CreateTicket.php
+++ b/lib/Model/CreateTicket.php
@@ -112,6 +112,8 @@ class CreateTicket implements \jsonSerializable
 
     /**
      * Serialize CreateTicket to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CustomField.php
+++ b/lib/Model/CustomField.php
@@ -199,10 +199,8 @@ class CustomField implements \jsonSerializable
 
     /**
      * Serialize CustomField to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/CustomField.php
+++ b/lib/Model/CustomField.php
@@ -199,6 +199,8 @@ class CustomField implements \jsonSerializable
 
     /**
      * Serialize CustomField to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CustomFieldQuery.php
+++ b/lib/Model/CustomFieldQuery.php
@@ -107,6 +107,8 @@ class CustomFieldQuery implements \jsonSerializable
 
     /**
      * Serialize CustomFieldQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CustomFieldQuery.php
+++ b/lib/Model/CustomFieldQuery.php
@@ -107,10 +107,8 @@ class CustomFieldQuery implements \jsonSerializable
 
     /**
      * Serialize CustomFieldQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/CustomFieldValue.php
+++ b/lib/Model/CustomFieldValue.php
@@ -146,6 +146,8 @@ class CustomFieldValue implements \jsonSerializable
 
     /**
      * Serialize CustomFieldValue to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CustomFieldValue.php
+++ b/lib/Model/CustomFieldValue.php
@@ -146,10 +146,8 @@ class CustomFieldValue implements \jsonSerializable
 
     /**
      * Serialize CustomFieldValue to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/CustomFieldValueQuery.php
+++ b/lib/Model/CustomFieldValueQuery.php
@@ -107,10 +107,8 @@ class CustomFieldValueQuery implements \jsonSerializable
 
     /**
      * Serialize CustomFieldValueQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/CustomFieldValueQuery.php
+++ b/lib/Model/CustomFieldValueQuery.php
@@ -107,6 +107,8 @@ class CustomFieldValueQuery implements \jsonSerializable
 
     /**
      * Serialize CustomFieldValueQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CustomfieldAvailability.php
+++ b/lib/Model/CustomfieldAvailability.php
@@ -101,6 +101,8 @@ class CustomfieldAvailability implements \jsonSerializable
 
     /**
      * Serialize CustomfieldAvailability to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/CustomfieldAvailability.php
+++ b/lib/Model/CustomfieldAvailability.php
@@ -101,10 +101,8 @@ class CustomfieldAvailability implements \jsonSerializable
 
     /**
      * Serialize CustomfieldAvailability to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->saleschannels)) {
             $result["saleschannels"] = $this->saleschannels;

--- a/lib/Model/DeleteProducts.php
+++ b/lib/Model/DeleteProducts.php
@@ -78,10 +78,8 @@ class DeleteProducts implements \jsonSerializable
 
     /**
      * Serialize DeleteProducts to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->products)) {
             $result["products"] = $this->products;

--- a/lib/Model/DeleteProducts.php
+++ b/lib/Model/DeleteProducts.php
@@ -78,6 +78,8 @@ class DeleteProducts implements \jsonSerializable
 
     /**
      * Serialize DeleteProducts to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DeleteTickets.php
+++ b/lib/Model/DeleteTickets.php
@@ -78,6 +78,8 @@ class DeleteTickets implements \jsonSerializable
 
     /**
      * Serialize DeleteTickets to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DeleteTickets.php
+++ b/lib/Model/DeleteTickets.php
@@ -78,10 +78,8 @@ class DeleteTickets implements \jsonSerializable
 
     /**
      * Serialize DeleteTickets to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->tickets)) {
             $result["tickets"] = $this->tickets;

--- a/lib/Model/DeliveryScenario.php
+++ b/lib/Model/DeliveryScenario.php
@@ -261,6 +261,8 @@ class DeliveryScenario implements \jsonSerializable
 
     /**
      * Serialize DeliveryScenario to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DeliveryScenario.php
+++ b/lib/Model/DeliveryScenario.php
@@ -261,10 +261,8 @@ class DeliveryScenario implements \jsonSerializable
 
     /**
      * Serialize DeliveryScenario to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/DeliveryScenarioQuery.php
+++ b/lib/Model/DeliveryScenarioQuery.php
@@ -99,6 +99,8 @@ class DeliveryScenarioQuery implements \jsonSerializable
 
     /**
      * Serialize DeliveryScenarioQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DeliveryScenarioQuery.php
+++ b/lib/Model/DeliveryScenarioQuery.php
@@ -99,10 +99,8 @@ class DeliveryScenarioQuery implements \jsonSerializable
 
     /**
      * Serialize DeliveryScenarioQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/DeliveryscenarioAvailability.php
+++ b/lib/Model/DeliveryscenarioAvailability.php
@@ -155,6 +155,8 @@ class DeliveryscenarioAvailability implements \jsonSerializable
 
     /**
      * Serialize DeliveryscenarioAvailability to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DeliveryscenarioAvailability.php
+++ b/lib/Model/DeliveryscenarioAvailability.php
@@ -155,10 +155,8 @@ class DeliveryscenarioAvailability implements \jsonSerializable
 
     /**
      * Serialize DeliveryscenarioAvailability to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->saleschannels)) {
             $result["saleschannels"] = $this->saleschannels;

--- a/lib/Model/Document.php
+++ b/lib/Model/Document.php
@@ -183,10 +183,8 @@ class Document implements \jsonSerializable
 
     /**
      * Serialize Document to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Document.php
+++ b/lib/Model/Document.php
@@ -183,6 +183,8 @@ class Document implements \jsonSerializable
 
     /**
      * Serialize Document to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DocumentOptions.php
+++ b/lib/Model/DocumentOptions.php
@@ -78,9 +78,9 @@ class DocumentOptions implements \jsonSerializable
     /**
      * Serialize DocumentOptions to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->nbrperpage)) {
             $result["nbrperpage"] = intval($this->nbrperpage);

--- a/lib/Model/DocumentQuery.php
+++ b/lib/Model/DocumentQuery.php
@@ -99,6 +99,8 @@ class DocumentQuery implements \jsonSerializable
 
     /**
      * Serialize DocumentQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DocumentQuery.php
+++ b/lib/Model/DocumentQuery.php
@@ -99,10 +99,8 @@ class DocumentQuery implements \jsonSerializable
 
     /**
      * Serialize DocumentQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/DupeDetectCriteria.php
+++ b/lib/Model/DupeDetectCriteria.php
@@ -87,6 +87,8 @@ class DupeDetectCriteria implements \jsonSerializable
 
     /**
      * Serialize DupeDetectCriteria to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DupeDetectCriteria.php
+++ b/lib/Model/DupeDetectCriteria.php
@@ -87,10 +87,8 @@ class DupeDetectCriteria implements \jsonSerializable
 
     /**
      * Serialize DupeDetectCriteria to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->field)) {
             $result["field"] = strval($this->field);

--- a/lib/Model/DupeDetectRule.php
+++ b/lib/Model/DupeDetectRule.php
@@ -126,6 +126,8 @@ class DupeDetectRule implements \jsonSerializable
 
     /**
      * Serialize DupeDetectRule to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/DupeDetectRule.php
+++ b/lib/Model/DupeDetectRule.php
@@ -126,10 +126,8 @@ class DupeDetectRule implements \jsonSerializable
 
     /**
      * Serialize DupeDetectRule to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/DupeDetectRuleQuery.php
+++ b/lib/Model/DupeDetectRuleQuery.php
@@ -91,10 +91,8 @@ class DupeDetectRuleQuery implements \jsonSerializable
 
     /**
      * Serialize DupeDetectRuleQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/DupeDetectRuleQuery.php
+++ b/lib/Model/DupeDetectRuleQuery.php
@@ -91,6 +91,8 @@ class DupeDetectRuleQuery implements \jsonSerializable
 
     /**
      * Serialize DupeDetectRuleQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Event.php
+++ b/lib/Model/Event.php
@@ -612,6 +612,8 @@ class Event implements \jsonSerializable
 
     /**
      * Serialize Event to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Event.php
+++ b/lib/Model/Event.php
@@ -612,10 +612,8 @@ class Event implements \jsonSerializable
 
     /**
      * Serialize Event to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/EventContext.php
+++ b/lib/Model/EventContext.php
@@ -83,6 +83,8 @@ class EventContext implements \jsonSerializable
 
     /**
      * Serialize EventContext to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventContext.php
+++ b/lib/Model/EventContext.php
@@ -83,10 +83,8 @@ class EventContext implements \jsonSerializable
 
     /**
      * Serialize EventContext to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->saleschannelid)) {
             $result["saleschannelid"] = intval($this->saleschannelid);

--- a/lib/Model/EventContingent.php
+++ b/lib/Model/EventContingent.php
@@ -137,10 +137,8 @@ class EventContingent implements \jsonSerializable
 
     /**
      * Serialize EventContingent to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/EventContingent.php
+++ b/lib/Model/EventContingent.php
@@ -137,6 +137,8 @@ class EventContingent implements \jsonSerializable
 
     /**
      * Serialize EventContingent to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventContingentAvailability.php
+++ b/lib/Model/EventContingentAvailability.php
@@ -149,10 +149,8 @@ class EventContingentAvailability implements \jsonSerializable
 
     /**
      * Serialize EventContingentAvailability to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->complimentary)) {
             $result["complimentary"] = intval($this->complimentary);

--- a/lib/Model/EventContingentAvailability.php
+++ b/lib/Model/EventContingentAvailability.php
@@ -149,6 +149,8 @@ class EventContingentAvailability implements \jsonSerializable
 
     /**
      * Serialize EventContingentAvailability to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventContingentLock.php
+++ b/lib/Model/EventContingentLock.php
@@ -93,10 +93,8 @@ class EventContingentLock implements \jsonSerializable
 
     /**
      * Serialize EventContingentLock to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = intval($this->amount);

--- a/lib/Model/EventContingentLock.php
+++ b/lib/Model/EventContingentLock.php
@@ -93,6 +93,8 @@ class EventContingentLock implements \jsonSerializable
 
     /**
      * Serialize EventContingentLock to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventFilter.php
+++ b/lib/Model/EventFilter.php
@@ -88,6 +88,8 @@ class EventFilter implements \jsonSerializable
 
     /**
      * Serialize EventFilter to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventFilter.php
+++ b/lib/Model/EventFilter.php
@@ -88,10 +88,8 @@ class EventFilter implements \jsonSerializable
 
     /**
      * Serialize EventFilter to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->productionid)) {
             $result["productionid"] = intval($this->productionid);

--- a/lib/Model/EventLocation.php
+++ b/lib/Model/EventLocation.php
@@ -235,6 +235,8 @@ class EventLocation implements \jsonSerializable
 
     /**
      * Serialize EventLocation to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventLocation.php
+++ b/lib/Model/EventLocation.php
@@ -235,10 +235,8 @@ class EventLocation implements \jsonSerializable
 
     /**
      * Serialize EventLocation to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/EventLocationQuery.php
+++ b/lib/Model/EventLocationQuery.php
@@ -99,10 +99,8 @@ class EventLocationQuery implements \jsonSerializable
 
     /**
      * Serialize EventLocationQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/EventLocationQuery.php
+++ b/lib/Model/EventLocationQuery.php
@@ -99,6 +99,8 @@ class EventLocationQuery implements \jsonSerializable
 
     /**
      * Serialize EventLocationQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventLockTickets.php
+++ b/lib/Model/EventLockTickets.php
@@ -86,10 +86,8 @@ class EventLockTickets implements \jsonSerializable
 
     /**
      * Serialize EventLockTickets to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->locktypeid)) {
             $result["locktypeid"] = intval($this->locktypeid);

--- a/lib/Model/EventLockTickets.php
+++ b/lib/Model/EventLockTickets.php
@@ -86,6 +86,8 @@ class EventLockTickets implements \jsonSerializable
 
     /**
      * Serialize EventLockTickets to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPreview.php
+++ b/lib/Model/EventPreview.php
@@ -118,6 +118,8 @@ class EventPreview implements \jsonSerializable
 
     /**
      * Serialize EventPreview to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPreview.php
+++ b/lib/Model/EventPreview.php
@@ -118,10 +118,8 @@ class EventPreview implements \jsonSerializable
 
     /**
      * Serialize EventPreview to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->linkurl)) {
             $result["linkurl"] = strval($this->linkurl);

--- a/lib/Model/EventPrices.php
+++ b/lib/Model/EventPrices.php
@@ -77,10 +77,8 @@ class EventPrices implements \jsonSerializable
 
     /**
      * Serialize EventPrices to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->contingents)) {
             $result["contingents"] = $this->contingents;

--- a/lib/Model/EventPrices.php
+++ b/lib/Model/EventPrices.php
@@ -77,6 +77,8 @@ class EventPrices implements \jsonSerializable
 
     /**
      * Serialize EventPrices to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPricesContingent.php
+++ b/lib/Model/EventPricesContingent.php
@@ -85,10 +85,8 @@ class EventPricesContingent implements \jsonSerializable
 
     /**
      * Serialize EventPricesContingent to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->contingentid)) {
             $result["contingentid"] = intval($this->contingentid);

--- a/lib/Model/EventPricesContingent.php
+++ b/lib/Model/EventPricesContingent.php
@@ -85,6 +85,8 @@ class EventPricesContingent implements \jsonSerializable
 
     /**
      * Serialize EventPricesContingent to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPricesCost.php
+++ b/lib/Model/EventPricesCost.php
@@ -85,10 +85,8 @@ class EventPricesCost implements \jsonSerializable
 
     /**
      * Serialize EventPricesCost to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->cost)) {
             $result["cost"] = floatval($this->cost);

--- a/lib/Model/EventPricesCost.php
+++ b/lib/Model/EventPricesCost.php
@@ -85,6 +85,8 @@ class EventPricesCost implements \jsonSerializable
 
     /**
      * Serialize EventPricesCost to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPricesPricetype.php
+++ b/lib/Model/EventPricesPricetype.php
@@ -94,10 +94,8 @@ class EventPricesPricetype implements \jsonSerializable
 
     /**
      * Serialize EventPricesPricetype to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->pricetypeid)) {
             $result["pricetypeid"] = intval($this->pricetypeid);

--- a/lib/Model/EventPricesPricetype.php
+++ b/lib/Model/EventPricesPricetype.php
@@ -94,6 +94,8 @@ class EventPricesPricetype implements \jsonSerializable
 
     /**
      * Serialize EventPricesPricetype to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPricesSaleschannel.php
+++ b/lib/Model/EventPricesSaleschannel.php
@@ -119,6 +119,8 @@ class EventPricesSaleschannel implements \jsonSerializable
 
     /**
      * Serialize EventPricesSaleschannel to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventPricesSaleschannel.php
+++ b/lib/Model/EventPricesSaleschannel.php
@@ -119,10 +119,8 @@ class EventPricesSaleschannel implements \jsonSerializable
 
     /**
      * Serialize EventPricesSaleschannel to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->conditions)) {
             $result["conditions"] = $this->conditions;

--- a/lib/Model/EventQuery.php
+++ b/lib/Model/EventQuery.php
@@ -164,6 +164,8 @@ class EventQuery implements \jsonSerializable
 
     /**
      * Serialize EventQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventQuery.php
+++ b/lib/Model/EventQuery.php
@@ -164,10 +164,8 @@ class EventQuery implements \jsonSerializable
 
     /**
      * Serialize EventQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->context)) {
             $result["context"] = $this->context;

--- a/lib/Model/EventSalesChannel.php
+++ b/lib/Model/EventSalesChannel.php
@@ -118,6 +118,8 @@ class EventSalesChannel implements \jsonSerializable
 
     /**
      * Serialize EventSalesChannel to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventSalesChannel.php
+++ b/lib/Model/EventSalesChannel.php
@@ -118,10 +118,8 @@ class EventSalesChannel implements \jsonSerializable
 
     /**
      * Serialize EventSalesChannel to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->eventid)) {
             $result["eventid"] = intval($this->eventid);

--- a/lib/Model/EventScanTicketsOut.php
+++ b/lib/Model/EventScanTicketsOut.php
@@ -77,10 +77,8 @@ class EventScanTicketsOut implements \jsonSerializable
 
     /**
      * Serialize EventScanTicketsOut to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->tickettypeids)) {
             $result["tickettypeids"] = $this->tickettypeids;

--- a/lib/Model/EventScanTicketsOut.php
+++ b/lib/Model/EventScanTicketsOut.php
@@ -77,6 +77,8 @@ class EventScanTicketsOut implements \jsonSerializable
 
     /**
      * Serialize EventScanTicketsOut to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventSeatingplanContingent.php
+++ b/lib/Model/EventSeatingplanContingent.php
@@ -110,10 +110,8 @@ class EventSeatingplanContingent implements \jsonSerializable
 
     /**
      * Serialize EventSeatingplanContingent to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/EventSeatingplanContingent.php
+++ b/lib/Model/EventSeatingplanContingent.php
@@ -110,6 +110,8 @@ class EventSeatingplanContingent implements \jsonSerializable
 
     /**
      * Serialize EventSeatingplanContingent to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventTicket.php
+++ b/lib/Model/EventTicket.php
@@ -378,6 +378,8 @@ class EventTicket implements \jsonSerializable
 
     /**
      * Serialize EventTicket to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventTicket.php
+++ b/lib/Model/EventTicket.php
@@ -378,10 +378,8 @@ class EventTicket implements \jsonSerializable
 
     /**
      * Serialize EventTicket to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/EventTicketFilter.php
+++ b/lib/Model/EventTicketFilter.php
@@ -77,10 +77,8 @@ class EventTicketFilter implements \jsonSerializable
 
     /**
      * Serialize EventTicketFilter to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->tickettypeid)) {
             $result["tickettypeid"] = intval($this->tickettypeid);

--- a/lib/Model/EventTicketFilter.php
+++ b/lib/Model/EventTicketFilter.php
@@ -77,6 +77,8 @@ class EventTicketFilter implements \jsonSerializable
 
     /**
      * Serialize EventTicketFilter to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventTicketQuery.php
+++ b/lib/Model/EventTicketQuery.php
@@ -77,6 +77,8 @@ class EventTicketQuery implements \jsonSerializable
 
     /**
      * Serialize EventTicketQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventTicketQuery.php
+++ b/lib/Model/EventTicketQuery.php
@@ -77,10 +77,8 @@ class EventTicketQuery implements \jsonSerializable
 
     /**
      * Serialize EventTicketQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->simplefilter)) {
             $result["simplefilter"] = $this->simplefilter;

--- a/lib/Model/EventUnlockTickets.php
+++ b/lib/Model/EventUnlockTickets.php
@@ -77,6 +77,8 @@ class EventUnlockTickets implements \jsonSerializable
 
     /**
      * Serialize EventUnlockTickets to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventUnlockTickets.php
+++ b/lib/Model/EventUnlockTickets.php
@@ -77,10 +77,8 @@ class EventUnlockTickets implements \jsonSerializable
 
     /**
      * Serialize EventUnlockTickets to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->ticketids)) {
             $result["ticketids"] = $this->ticketids;

--- a/lib/Model/EventUpdateSeatRankForTickets.php
+++ b/lib/Model/EventUpdateSeatRankForTickets.php
@@ -85,6 +85,8 @@ class EventUpdateSeatRankForTickets implements \jsonSerializable
 
     /**
      * Serialize EventUpdateSeatRankForTickets to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/EventUpdateSeatRankForTickets.php
+++ b/lib/Model/EventUpdateSeatRankForTickets.php
@@ -85,10 +85,8 @@ class EventUpdateSeatRankForTickets implements \jsonSerializable
 
     /**
      * Serialize EventUpdateSeatRankForTickets to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->seatrankid)) {
             $result["seatrankid"] = intval($this->seatrankid);

--- a/lib/Model/EventUpsellitem.php
+++ b/lib/Model/EventUpsellitem.php
@@ -86,9 +86,9 @@ class EventUpsellitem implements \jsonSerializable
     /**
      * Serialize EventUpsellitem to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/EventstreamItem.php
+++ b/lib/Model/EventstreamItem.php
@@ -102,9 +102,9 @@ class EventstreamItem implements \jsonSerializable
     /**
      * Serialize EventstreamItem to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = strval($this->id);

--- a/lib/Model/EventstreamRequest.php
+++ b/lib/Model/EventstreamRequest.php
@@ -95,9 +95,9 @@ class EventstreamRequest implements \jsonSerializable
     /**
      * Serialize EventstreamRequest to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = strval($this->id);

--- a/lib/Model/EventstreamResult.php
+++ b/lib/Model/EventstreamResult.php
@@ -94,9 +94,9 @@ class EventstreamResult implements \jsonSerializable
     /**
      * Serialize EventstreamResult to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->moreresults)) {
             $result["moreresults"] = (bool)$this->moreresults;

--- a/lib/Model/FieldDefinition.php
+++ b/lib/Model/FieldDefinition.php
@@ -191,10 +191,8 @@ class FieldDefinition implements \jsonSerializable
 
     /**
      * Serialize FieldDefinition to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/FieldDefinition.php
+++ b/lib/Model/FieldDefinition.php
@@ -191,6 +191,8 @@ class FieldDefinition implements \jsonSerializable
 
     /**
      * Serialize FieldDefinition to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/FieldDefinitionQuery.php
+++ b/lib/Model/FieldDefinitionQuery.php
@@ -107,10 +107,8 @@ class FieldDefinitionQuery implements \jsonSerializable
 
     /**
      * Serialize FieldDefinitionQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/FieldDefinitionQuery.php
+++ b/lib/Model/FieldDefinitionQuery.php
@@ -107,6 +107,8 @@ class FieldDefinitionQuery implements \jsonSerializable
 
     /**
      * Serialize FieldDefinitionQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/FielddefinitionsDataRequest.php
+++ b/lib/Model/FielddefinitionsDataRequest.php
@@ -93,10 +93,8 @@ class FielddefinitionsDataRequest implements \jsonSerializable
 
     /**
      * Serialize FielddefinitionsDataRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/FielddefinitionsDataRequest.php
+++ b/lib/Model/FielddefinitionsDataRequest.php
@@ -93,6 +93,8 @@ class FielddefinitionsDataRequest implements \jsonSerializable
 
     /**
      * Serialize FielddefinitionsDataRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/FielddefinitionsDataResult.php
+++ b/lib/Model/FielddefinitionsDataResult.php
@@ -85,10 +85,8 @@ class FielddefinitionsDataResult implements \jsonSerializable
 
     /**
      * Serialize FielddefinitionsDataResult to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/FielddefinitionsDataResult.php
+++ b/lib/Model/FielddefinitionsDataResult.php
@@ -85,6 +85,8 @@ class FielddefinitionsDataResult implements \jsonSerializable
 
     /**
      * Serialize FielddefinitionsDataResult to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/FilterDefinition.php
+++ b/lib/Model/FilterDefinition.php
@@ -173,10 +173,8 @@ class FilterDefinition implements \jsonSerializable
 
     /**
      * Serialize FilterDefinition to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/FilterDefinition.php
+++ b/lib/Model/FilterDefinition.php
@@ -173,6 +173,8 @@ class FilterDefinition implements \jsonSerializable
 
     /**
      * Serialize FilterDefinition to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/FilterDefinitionQuery.php
+++ b/lib/Model/FilterDefinitionQuery.php
@@ -107,10 +107,8 @@ class FilterDefinitionQuery implements \jsonSerializable
 
     /**
      * Serialize FilterDefinitionQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/FilterDefinitionQuery.php
+++ b/lib/Model/FilterDefinitionQuery.php
@@ -107,6 +107,8 @@ class FilterDefinitionQuery implements \jsonSerializable
 
     /**
      * Serialize FilterDefinitionQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/FilterItem.php
+++ b/lib/Model/FilterItem.php
@@ -87,10 +87,8 @@ class FilterItem implements \jsonSerializable
 
     /**
      * Serialize FilterItem to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/FilterItem.php
+++ b/lib/Model/FilterItem.php
@@ -87,6 +87,8 @@ class FilterItem implements \jsonSerializable
 
     /**
      * Serialize FilterItem to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Flowinfo.php
+++ b/lib/Model/Flowinfo.php
@@ -93,6 +93,8 @@ class Flowinfo implements \jsonSerializable
 
     /**
      * Serialize Flowinfo to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Flowinfo.php
+++ b/lib/Model/Flowinfo.php
@@ -93,10 +93,8 @@ class Flowinfo implements \jsonSerializable
 
     /**
      * Serialize Flowinfo to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->contactid)) {
             $result["contactid"] = intval($this->contactid);

--- a/lib/Model/Flowsession.php
+++ b/lib/Model/Flowsession.php
@@ -85,10 +85,8 @@ class Flowsession implements \jsonSerializable
 
     /**
      * Serialize Flowsession to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->orderid)) {
             $result["orderid"] = intval($this->orderid);

--- a/lib/Model/Flowsession.php
+++ b/lib/Model/Flowsession.php
@@ -85,6 +85,8 @@ class Flowsession implements \jsonSerializable
 
     /**
      * Serialize Flowsession to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportBundleTicket.php
+++ b/lib/Model/ImportBundleTicket.php
@@ -123,6 +123,8 @@ class ImportBundleTicket implements \jsonSerializable
 
     /**
      * Serialize ImportBundleTicket to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportBundleTicket.php
+++ b/lib/Model/ImportBundleTicket.php
@@ -123,10 +123,8 @@ class ImportBundleTicket implements \jsonSerializable
 
     /**
      * Serialize ImportBundleTicket to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ImportOrder.php
+++ b/lib/Model/ImportOrder.php
@@ -245,10 +245,8 @@ class ImportOrder implements \jsonSerializable
 
     /**
      * Serialize ImportOrder to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->orderid)) {
             $result["orderid"] = intval($this->orderid);

--- a/lib/Model/ImportOrder.php
+++ b/lib/Model/ImportOrder.php
@@ -245,6 +245,8 @@ class ImportOrder implements \jsonSerializable
 
     /**
      * Serialize ImportOrder to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportOrdercost.php
+++ b/lib/Model/ImportOrdercost.php
@@ -85,6 +85,8 @@ class ImportOrdercost implements \jsonSerializable
 
     /**
      * Serialize ImportOrdercost to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportOrdercost.php
+++ b/lib/Model/ImportOrdercost.php
@@ -85,10 +85,8 @@ class ImportOrdercost implements \jsonSerializable
 
     /**
      * Serialize ImportOrdercost to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/ImportPayment.php
+++ b/lib/Model/ImportPayment.php
@@ -117,10 +117,8 @@ class ImportPayment implements \jsonSerializable
 
     /**
      * Serialize ImportPayment to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/ImportPayment.php
+++ b/lib/Model/ImportPayment.php
@@ -117,6 +117,8 @@ class ImportPayment implements \jsonSerializable
 
     /**
      * Serialize ImportPayment to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportProduct.php
+++ b/lib/Model/ImportProduct.php
@@ -147,10 +147,8 @@ class ImportProduct implements \jsonSerializable
 
     /**
      * Serialize ImportProduct to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->bundletickets)) {
             $result["bundletickets"] = $this->bundletickets;

--- a/lib/Model/ImportProduct.php
+++ b/lib/Model/ImportProduct.php
@@ -147,6 +147,8 @@ class ImportProduct implements \jsonSerializable
 
     /**
      * Serialize ImportProduct to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportTicket.php
+++ b/lib/Model/ImportTicket.php
@@ -168,6 +168,8 @@ class ImportTicket implements \jsonSerializable
 
     /**
      * Serialize ImportTicket to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ImportTicket.php
+++ b/lib/Model/ImportTicket.php
@@ -168,10 +168,8 @@ class ImportTicket implements \jsonSerializable
 
     /**
      * Serialize ImportTicket to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/JobResult.php
+++ b/lib/Model/JobResult.php
@@ -109,10 +109,8 @@ class JobResult implements \jsonSerializable
 
     /**
      * Serialize JobResult to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = strval($this->id);

--- a/lib/Model/JobResult.php
+++ b/lib/Model/JobResult.php
@@ -109,6 +109,8 @@ class JobResult implements \jsonSerializable
 
     /**
      * Serialize JobResult to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/KeyValueItem.php
+++ b/lib/Model/KeyValueItem.php
@@ -85,6 +85,8 @@ class KeyValueItem implements \jsonSerializable
 
     /**
      * Serialize KeyValueItem to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/KeyValueItem.php
+++ b/lib/Model/KeyValueItem.php
@@ -85,10 +85,8 @@ class KeyValueItem implements \jsonSerializable
 
     /**
      * Serialize KeyValueItem to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->key)) {
             $result["key"] = strval($this->key);

--- a/lib/Model/Layout.php
+++ b/lib/Model/Layout.php
@@ -86,9 +86,9 @@ class Layout implements \jsonSerializable
     /**
      * Serialize Layout to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->color)) {
             $result["color"] = strval($this->color);

--- a/lib/Model/LockTemplate.php
+++ b/lib/Model/LockTemplate.php
@@ -86,10 +86,8 @@ class LockTemplate implements \jsonSerializable
 
     /**
      * Serialize LockTemplate to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->name)) {
             $result["name"] = strval($this->name);

--- a/lib/Model/LockTemplate.php
+++ b/lib/Model/LockTemplate.php
@@ -86,6 +86,8 @@ class LockTemplate implements \jsonSerializable
 
     /**
      * Serialize LockTemplate to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LockType.php
+++ b/lib/Model/LockType.php
@@ -153,10 +153,8 @@ class LockType implements \jsonSerializable
 
     /**
      * Serialize LockType to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/LockType.php
+++ b/lib/Model/LockType.php
@@ -153,6 +153,8 @@ class LockType implements \jsonSerializable
 
     /**
      * Serialize LockType to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LockTypeQuery.php
+++ b/lib/Model/LockTypeQuery.php
@@ -99,10 +99,8 @@ class LockTypeQuery implements \jsonSerializable
 
     /**
      * Serialize LockTypeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/LockTypeQuery.php
+++ b/lib/Model/LockTypeQuery.php
@@ -99,6 +99,8 @@ class LockTypeQuery implements \jsonSerializable
 
     /**
      * Serialize LockTypeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LogItem.php
+++ b/lib/Model/LogItem.php
@@ -203,10 +203,8 @@ class LogItem implements \jsonSerializable
 
     /**
      * Serialize LogItem to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/LogItem.php
+++ b/lib/Model/LogItem.php
@@ -203,6 +203,8 @@ class LogItem implements \jsonSerializable
 
     /**
      * Serialize LogItem to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LogicalPlan.php
+++ b/lib/Model/LogicalPlan.php
@@ -93,10 +93,8 @@ class LogicalPlan implements \jsonSerializable
 
     /**
      * Serialize LogicalPlan to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/LogicalPlan.php
+++ b/lib/Model/LogicalPlan.php
@@ -93,6 +93,8 @@ class LogicalPlan implements \jsonSerializable
 
     /**
      * Serialize LogicalPlan to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LogicalPlanRow.php
+++ b/lib/Model/LogicalPlanRow.php
@@ -93,6 +93,8 @@ class LogicalPlanRow implements \jsonSerializable
 
     /**
      * Serialize LogicalPlanRow to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LogicalPlanRow.php
+++ b/lib/Model/LogicalPlanRow.php
@@ -93,10 +93,8 @@ class LogicalPlanRow implements \jsonSerializable
 
     /**
      * Serialize LogicalPlanRow to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->name)) {
             $result["name"] = strval($this->name);

--- a/lib/Model/LogicalPlanSeat.php
+++ b/lib/Model/LogicalPlanSeat.php
@@ -141,6 +141,8 @@ class LogicalPlanSeat implements \jsonSerializable
 
     /**
      * Serialize LogicalPlanSeat to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/LogicalPlanSeat.php
+++ b/lib/Model/LogicalPlanSeat.php
@@ -141,10 +141,8 @@ class LogicalPlanSeat implements \jsonSerializable
 
     /**
      * Serialize LogicalPlanSeat to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = strval($this->id);

--- a/lib/Model/OptIn.php
+++ b/lib/Model/OptIn.php
@@ -176,10 +176,8 @@ class OptIn implements \jsonSerializable
 
     /**
      * Serialize OptIn to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OptIn.php
+++ b/lib/Model/OptIn.php
@@ -176,6 +176,8 @@ class OptIn implements \jsonSerializable
 
     /**
      * Serialize OptIn to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OptInAvailability.php
+++ b/lib/Model/OptInAvailability.php
@@ -77,6 +77,8 @@ class OptInAvailability implements \jsonSerializable
 
     /**
      * Serialize OptInAvailability to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OptInAvailability.php
+++ b/lib/Model/OptInAvailability.php
@@ -77,10 +77,8 @@ class OptInAvailability implements \jsonSerializable
 
     /**
      * Serialize OptInAvailability to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->saleschannelid)) {
             $result["saleschannelid"] = intval($this->saleschannelid);

--- a/lib/Model/OptInQuery.php
+++ b/lib/Model/OptInQuery.php
@@ -99,10 +99,8 @@ class OptInQuery implements \jsonSerializable
 
     /**
      * Serialize OptInQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/OptInQuery.php
+++ b/lib/Model/OptInQuery.php
@@ -99,6 +99,8 @@ class OptInQuery implements \jsonSerializable
 
     /**
      * Serialize OptInQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Order.php
+++ b/lib/Model/Order.php
@@ -417,6 +417,8 @@ class Order implements \jsonSerializable
 
     /**
      * Serialize Order to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Order.php
+++ b/lib/Model/Order.php
@@ -417,10 +417,8 @@ class Order implements \jsonSerializable
 
     /**
      * Serialize Order to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->orderid)) {
             $result["orderid"] = intval($this->orderid);

--- a/lib/Model/OrderFee.php
+++ b/lib/Model/OrderFee.php
@@ -160,10 +160,8 @@ class OrderFee implements \jsonSerializable
 
     /**
      * Serialize OrderFee to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderFee.php
+++ b/lib/Model/OrderFee.php
@@ -160,6 +160,8 @@ class OrderFee implements \jsonSerializable
 
     /**
      * Serialize OrderFee to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderFeeDefinition.php
+++ b/lib/Model/OrderFeeDefinition.php
@@ -161,6 +161,8 @@ class OrderFeeDefinition implements \jsonSerializable
 
     /**
      * Serialize OrderFeeDefinition to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderFeeDefinition.php
+++ b/lib/Model/OrderFeeDefinition.php
@@ -161,10 +161,8 @@ class OrderFeeDefinition implements \jsonSerializable
 
     /**
      * Serialize OrderFeeDefinition to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderFeeDefinitionQuery.php
+++ b/lib/Model/OrderFeeDefinitionQuery.php
@@ -99,6 +99,8 @@ class OrderFeeDefinitionQuery implements \jsonSerializable
 
     /**
      * Serialize OrderFeeDefinitionQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderFeeDefinitionQuery.php
+++ b/lib/Model/OrderFeeDefinitionQuery.php
@@ -99,10 +99,8 @@ class OrderFeeDefinitionQuery implements \jsonSerializable
 
     /**
      * Serialize OrderFeeDefinitionQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/OrderFeeQuery.php
+++ b/lib/Model/OrderFeeQuery.php
@@ -99,10 +99,8 @@ class OrderFeeQuery implements \jsonSerializable
 
     /**
      * Serialize OrderFeeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/OrderFeeQuery.php
+++ b/lib/Model/OrderFeeQuery.php
@@ -99,6 +99,8 @@ class OrderFeeQuery implements \jsonSerializable
 
     /**
      * Serialize OrderFeeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderFilter.php
+++ b/lib/Model/OrderFilter.php
@@ -111,6 +111,8 @@ class OrderFilter implements \jsonSerializable
 
     /**
      * Serialize OrderFilter to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderFilter.php
+++ b/lib/Model/OrderFilter.php
@@ -111,10 +111,8 @@ class OrderFilter implements \jsonSerializable
 
     /**
      * Serialize OrderFilter to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->createdsince)) {
             $result["createdsince"] = Json::packTimestamp($this->createdsince);

--- a/lib/Model/OrderIdReservation.php
+++ b/lib/Model/OrderIdReservation.php
@@ -77,10 +77,8 @@ class OrderIdReservation implements \jsonSerializable
 
     /**
      * Serialize OrderIdReservation to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderIdReservation.php
+++ b/lib/Model/OrderIdReservation.php
@@ -77,6 +77,8 @@ class OrderIdReservation implements \jsonSerializable
 
     /**
      * Serialize OrderIdReservation to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderImportStatus.php
+++ b/lib/Model/OrderImportStatus.php
@@ -93,10 +93,8 @@ class OrderImportStatus implements \jsonSerializable
 
     /**
      * Serialize OrderImportStatus to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderImportStatus.php
+++ b/lib/Model/OrderImportStatus.php
@@ -93,6 +93,8 @@ class OrderImportStatus implements \jsonSerializable
 
     /**
      * Serialize OrderImportStatus to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderMailTemplate.php
+++ b/lib/Model/OrderMailTemplate.php
@@ -171,10 +171,8 @@ class OrderMailTemplate implements \jsonSerializable
 
     /**
      * Serialize OrderMailTemplate to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderMailTemplate.php
+++ b/lib/Model/OrderMailTemplate.php
@@ -171,6 +171,8 @@ class OrderMailTemplate implements \jsonSerializable
 
     /**
      * Serialize OrderMailTemplate to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderMailTemplateQuery.php
+++ b/lib/Model/OrderMailTemplateQuery.php
@@ -99,10 +99,8 @@ class OrderMailTemplateQuery implements \jsonSerializable
 
     /**
      * Serialize OrderMailTemplateQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/OrderMailTemplateQuery.php
+++ b/lib/Model/OrderMailTemplateQuery.php
@@ -99,6 +99,8 @@ class OrderMailTemplateQuery implements \jsonSerializable
 
     /**
      * Serialize OrderMailTemplateQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderProduct.php
+++ b/lib/Model/OrderProduct.php
@@ -150,6 +150,8 @@ class OrderProduct implements \jsonSerializable
 
     /**
      * Serialize OrderProduct to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderProduct.php
+++ b/lib/Model/OrderProduct.php
@@ -150,10 +150,8 @@ class OrderProduct implements \jsonSerializable
 
     /**
      * Serialize OrderProduct to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderQuery.php
+++ b/lib/Model/OrderQuery.php
@@ -169,6 +169,8 @@ class OrderQuery implements \jsonSerializable
 
     /**
      * Serialize OrderQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderQuery.php
+++ b/lib/Model/OrderQuery.php
@@ -169,10 +169,8 @@ class OrderQuery implements \jsonSerializable
 
     /**
      * Serialize OrderQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/OrderTicket.php
+++ b/lib/Model/OrderTicket.php
@@ -261,6 +261,8 @@ class OrderTicket implements \jsonSerializable
 
     /**
      * Serialize OrderTicket to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderTicket.php
+++ b/lib/Model/OrderTicket.php
@@ -261,10 +261,8 @@ class OrderTicket implements \jsonSerializable
 
     /**
      * Serialize OrderTicket to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/OrderTickettype.php
+++ b/lib/Model/OrderTickettype.php
@@ -93,6 +93,8 @@ class OrderTickettype implements \jsonSerializable
 
     /**
      * Serialize OrderTickettype to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderTickettype.php
+++ b/lib/Model/OrderTickettype.php
@@ -93,10 +93,8 @@ class OrderTickettype implements \jsonSerializable
 
     /**
      * Serialize OrderTickettype to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Ordercost.php
+++ b/lib/Model/Ordercost.php
@@ -93,6 +93,8 @@ class Ordercost implements \jsonSerializable
 
     /**
      * Serialize Ordercost to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Ordercost.php
+++ b/lib/Model/Ordercost.php
@@ -93,10 +93,8 @@ class Ordercost implements \jsonSerializable
 
     /**
      * Serialize Ordercost to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->orderid)) {
             $result["orderid"] = intval($this->orderid);

--- a/lib/Model/OrderfeeAutoRule.php
+++ b/lib/Model/OrderfeeAutoRule.php
@@ -116,10 +116,8 @@ class OrderfeeAutoRule implements \jsonSerializable
 
     /**
      * Serialize OrderfeeAutoRule to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->deliveryscenarioids)) {
             $result["deliveryscenarioids"] = $this->deliveryscenarioids;

--- a/lib/Model/OrderfeeAutoRule.php
+++ b/lib/Model/OrderfeeAutoRule.php
@@ -116,6 +116,8 @@ class OrderfeeAutoRule implements \jsonSerializable
 
     /**
      * Serialize OrderfeeAutoRule to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderfeeRule.php
+++ b/lib/Model/OrderfeeRule.php
@@ -97,6 +97,8 @@ class OrderfeeRule implements \jsonSerializable
 
     /**
      * Serialize OrderfeeRule to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderfeeRule.php
+++ b/lib/Model/OrderfeeRule.php
@@ -97,10 +97,8 @@ class OrderfeeRule implements \jsonSerializable
 
     /**
      * Serialize OrderfeeRule to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->auto)) {
             $result["auto"] = $this->auto;

--- a/lib/Model/OrderfeeScriptContext.php
+++ b/lib/Model/OrderfeeScriptContext.php
@@ -96,6 +96,8 @@ class OrderfeeScriptContext implements \jsonSerializable
 
     /**
      * Serialize OrderfeeScriptContext to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/OrderfeeScriptContext.php
+++ b/lib/Model/OrderfeeScriptContext.php
@@ -96,10 +96,8 @@ class OrderfeeScriptContext implements \jsonSerializable
 
     /**
      * Serialize OrderfeeScriptContext to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->cacheable)) {
             $result["cacheable"] = (bool)$this->cacheable;

--- a/lib/Model/Payment.php
+++ b/lib/Model/Payment.php
@@ -135,10 +135,8 @@ class Payment implements \jsonSerializable
 
     /**
      * Serialize Payment to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Payment.php
+++ b/lib/Model/Payment.php
@@ -135,6 +135,8 @@ class Payment implements \jsonSerializable
 
     /**
      * Serialize Payment to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentMethod.php
+++ b/lib/Model/PaymentMethod.php
@@ -181,6 +181,8 @@ class PaymentMethod implements \jsonSerializable
 
     /**
      * Serialize PaymentMethod to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentMethod.php
+++ b/lib/Model/PaymentMethod.php
@@ -181,10 +181,8 @@ class PaymentMethod implements \jsonSerializable
 
     /**
      * Serialize PaymentMethod to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/PaymentMethodQuery.php
+++ b/lib/Model/PaymentMethodQuery.php
@@ -99,10 +99,8 @@ class PaymentMethodQuery implements \jsonSerializable
 
     /**
      * Serialize PaymentMethodQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/PaymentMethodQuery.php
+++ b/lib/Model/PaymentMethodQuery.php
@@ -99,6 +99,8 @@ class PaymentMethodQuery implements \jsonSerializable
 
     /**
      * Serialize PaymentMethodQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentRequest.php
+++ b/lib/Model/PaymentRequest.php
@@ -94,10 +94,8 @@ class PaymentRequest implements \jsonSerializable
 
     /**
      * Serialize PaymentRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->language)) {
             $result["language"] = strval($this->language);

--- a/lib/Model/PaymentRequest.php
+++ b/lib/Model/PaymentRequest.php
@@ -94,6 +94,8 @@ class PaymentRequest implements \jsonSerializable
 
     /**
      * Serialize PaymentRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentScenario.php
+++ b/lib/Model/PaymentScenario.php
@@ -301,10 +301,8 @@ class PaymentScenario implements \jsonSerializable
 
     /**
      * Serialize PaymentScenario to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/PaymentScenario.php
+++ b/lib/Model/PaymentScenario.php
@@ -301,6 +301,8 @@ class PaymentScenario implements \jsonSerializable
 
     /**
      * Serialize PaymentScenario to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentScenarioQuery.php
+++ b/lib/Model/PaymentScenarioQuery.php
@@ -99,10 +99,8 @@ class PaymentScenarioQuery implements \jsonSerializable
 
     /**
      * Serialize PaymentScenarioQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/PaymentScenarioQuery.php
+++ b/lib/Model/PaymentScenarioQuery.php
@@ -99,6 +99,8 @@ class PaymentScenarioQuery implements \jsonSerializable
 
     /**
      * Serialize PaymentScenarioQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentscenarioAvailability.php
+++ b/lib/Model/PaymentscenarioAvailability.php
@@ -102,6 +102,8 @@ class PaymentscenarioAvailability implements \jsonSerializable
 
     /**
      * Serialize PaymentscenarioAvailability to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentscenarioAvailability.php
+++ b/lib/Model/PaymentscenarioAvailability.php
@@ -102,10 +102,8 @@ class PaymentscenarioAvailability implements \jsonSerializable
 
     /**
      * Serialize PaymentscenarioAvailability to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->saleschannels)) {
             $result["saleschannels"] = $this->saleschannels;

--- a/lib/Model/PaymentscenarioExpiryParameters.php
+++ b/lib/Model/PaymentscenarioExpiryParameters.php
@@ -110,6 +110,8 @@ class PaymentscenarioExpiryParameters implements \jsonSerializable
 
     /**
      * Serialize PaymentscenarioExpiryParameters to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PaymentscenarioExpiryParameters.php
+++ b/lib/Model/PaymentscenarioExpiryParameters.php
@@ -110,10 +110,8 @@ class PaymentscenarioExpiryParameters implements \jsonSerializable
 
     /**
      * Serialize PaymentscenarioExpiryParameters to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->daysaftercreation)) {
             $result["daysaftercreation"] = intval($this->daysaftercreation);

--- a/lib/Model/PaymentscenarioOverdueParameters.php
+++ b/lib/Model/PaymentscenarioOverdueParameters.php
@@ -101,10 +101,8 @@ class PaymentscenarioOverdueParameters implements \jsonSerializable
 
     /**
      * Serialize PaymentscenarioOverdueParameters to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->daysaftercreation)) {
             $result["daysaftercreation"] = intval($this->daysaftercreation);

--- a/lib/Model/PaymentscenarioOverdueParameters.php
+++ b/lib/Model/PaymentscenarioOverdueParameters.php
@@ -101,6 +101,8 @@ class PaymentscenarioOverdueParameters implements \jsonSerializable
 
     /**
      * Serialize PaymentscenarioOverdueParameters to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PhoneNumberType.php
+++ b/lib/Model/PhoneNumberType.php
@@ -128,10 +128,8 @@ class PhoneNumberType implements \jsonSerializable
 
     /**
      * Serialize PhoneNumberType to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/PhoneNumberType.php
+++ b/lib/Model/PhoneNumberType.php
@@ -128,6 +128,8 @@ class PhoneNumberType implements \jsonSerializable
 
     /**
      * Serialize PhoneNumberType to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PhoneNumberTypeQuery.php
+++ b/lib/Model/PhoneNumberTypeQuery.php
@@ -99,10 +99,8 @@ class PhoneNumberTypeQuery implements \jsonSerializable
 
     /**
      * Serialize PhoneNumberTypeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/PhoneNumberTypeQuery.php
+++ b/lib/Model/PhoneNumberTypeQuery.php
@@ -99,6 +99,8 @@ class PhoneNumberTypeQuery implements \jsonSerializable
 
     /**
      * Serialize PhoneNumberTypeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Phonenumber.php
+++ b/lib/Model/Phonenumber.php
@@ -109,10 +109,8 @@ class Phonenumber implements \jsonSerializable
 
     /**
      * Serialize Phonenumber to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Phonenumber.php
+++ b/lib/Model/Phonenumber.php
@@ -109,6 +109,8 @@ class Phonenumber implements \jsonSerializable
 
     /**
      * Serialize Phonenumber to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PriceList.php
+++ b/lib/Model/PriceList.php
@@ -146,10 +146,8 @@ class PriceList implements \jsonSerializable
 
     /**
      * Serialize PriceList to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/PriceList.php
+++ b/lib/Model/PriceList.php
@@ -146,6 +146,8 @@ class PriceList implements \jsonSerializable
 
     /**
      * Serialize PriceList to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PriceListQuery.php
+++ b/lib/Model/PriceListQuery.php
@@ -99,10 +99,8 @@ class PriceListQuery implements \jsonSerializable
 
     /**
      * Serialize PriceListQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/PriceListQuery.php
+++ b/lib/Model/PriceListQuery.php
@@ -99,6 +99,8 @@ class PriceListQuery implements \jsonSerializable
 
     /**
      * Serialize PriceListQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PriceType.php
+++ b/lib/Model/PriceType.php
@@ -163,6 +163,8 @@ class PriceType implements \jsonSerializable
 
     /**
      * Serialize PriceType to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PriceType.php
+++ b/lib/Model/PriceType.php
@@ -163,10 +163,8 @@ class PriceType implements \jsonSerializable
 
     /**
      * Serialize PriceType to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/PriceTypeQuery.php
+++ b/lib/Model/PriceTypeQuery.php
@@ -99,6 +99,8 @@ class PriceTypeQuery implements \jsonSerializable
 
     /**
      * Serialize PriceTypeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PriceTypeQuery.php
+++ b/lib/Model/PriceTypeQuery.php
@@ -99,10 +99,8 @@ class PriceTypeQuery implements \jsonSerializable
 
     /**
      * Serialize PriceTypeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/PricelistPrice.php
+++ b/lib/Model/PricelistPrice.php
@@ -123,10 +123,8 @@ class PricelistPrice implements \jsonSerializable
 
     /**
      * Serialize PricelistPrice to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->availabilities)) {
             $result["availabilities"] = $this->availabilities;

--- a/lib/Model/PricelistPrice.php
+++ b/lib/Model/PricelistPrice.php
@@ -123,6 +123,8 @@ class PricelistPrice implements \jsonSerializable
 
     /**
      * Serialize PricelistPrice to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PricelistPriceCondition.php
+++ b/lib/Model/PricelistPriceCondition.php
@@ -171,6 +171,8 @@ class PricelistPriceCondition implements \jsonSerializable
 
     /**
      * Serialize PricelistPriceCondition to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PricelistPriceCondition.php
+++ b/lib/Model/PricelistPriceCondition.php
@@ -171,10 +171,8 @@ class PricelistPriceCondition implements \jsonSerializable
 
     /**
      * Serialize PricelistPriceCondition to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->type)) {
             $result["type"] = strval($this->type);

--- a/lib/Model/PricelistPrices.php
+++ b/lib/Model/PricelistPrices.php
@@ -86,6 +86,8 @@ class PricelistPrices implements \jsonSerializable
 
     /**
      * Serialize PricelistPrices to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PricelistPrices.php
+++ b/lib/Model/PricelistPrices.php
@@ -86,10 +86,8 @@ class PricelistPrices implements \jsonSerializable
 
     /**
      * Serialize PricelistPrices to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->prices)) {
             $result["prices"] = $this->prices;

--- a/lib/Model/Product.php
+++ b/lib/Model/Product.php
@@ -329,6 +329,8 @@ class Product implements \jsonSerializable
 
     /**
      * Serialize Product to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Product.php
+++ b/lib/Model/Product.php
@@ -329,10 +329,8 @@ class Product implements \jsonSerializable
 
     /**
      * Serialize Product to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ProductCategory.php
+++ b/lib/Model/ProductCategory.php
@@ -152,6 +152,8 @@ class ProductCategory implements \jsonSerializable
 
     /**
      * Serialize ProductCategory to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductCategory.php
+++ b/lib/Model/ProductCategory.php
@@ -152,10 +152,8 @@ class ProductCategory implements \jsonSerializable
 
     /**
      * Serialize ProductCategory to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ProductCategoryQuery.php
+++ b/lib/Model/ProductCategoryQuery.php
@@ -99,6 +99,8 @@ class ProductCategoryQuery implements \jsonSerializable
 
     /**
      * Serialize ProductCategoryQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductCategoryQuery.php
+++ b/lib/Model/ProductCategoryQuery.php
@@ -99,10 +99,8 @@ class ProductCategoryQuery implements \jsonSerializable
 
     /**
      * Serialize ProductCategoryQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/ProductInstanceException.php
+++ b/lib/Model/ProductInstanceException.php
@@ -85,6 +85,8 @@ class ProductInstanceException implements \jsonSerializable
 
     /**
      * Serialize ProductInstanceException to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductInstanceException.php
+++ b/lib/Model/ProductInstanceException.php
@@ -85,10 +85,8 @@ class ProductInstanceException implements \jsonSerializable
 
     /**
      * Serialize ProductInstanceException to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->properties)) {
             $result["properties"] = $this->properties;

--- a/lib/Model/ProductInstancePricetypeValue.php
+++ b/lib/Model/ProductInstancePricetypeValue.php
@@ -85,6 +85,8 @@ class ProductInstancePricetypeValue implements \jsonSerializable
 
     /**
      * Serialize ProductInstancePricetypeValue to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductInstancePricetypeValue.php
+++ b/lib/Model/ProductInstancePricetypeValue.php
@@ -85,10 +85,8 @@ class ProductInstancePricetypeValue implements \jsonSerializable
 
     /**
      * Serialize ProductInstancePricetypeValue to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ProductInstanceValue.php
+++ b/lib/Model/ProductInstanceValue.php
@@ -126,6 +126,8 @@ class ProductInstanceValue implements \jsonSerializable
 
     /**
      * Serialize ProductInstanceValue to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductInstanceValue.php
+++ b/lib/Model/ProductInstanceValue.php
@@ -126,10 +126,8 @@ class ProductInstanceValue implements \jsonSerializable
 
     /**
      * Serialize ProductInstanceValue to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->max_price)) {
             $result["max_price"] = floatval($this->max_price);

--- a/lib/Model/ProductInstancevalues.php
+++ b/lib/Model/ProductInstancevalues.php
@@ -88,10 +88,8 @@ class ProductInstancevalues implements \jsonSerializable
 
     /**
      * Serialize ProductInstancevalues to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->default)) {
             $result["default"] = $this->default;

--- a/lib/Model/ProductInstancevalues.php
+++ b/lib/Model/ProductInstancevalues.php
@@ -88,6 +88,8 @@ class ProductInstancevalues implements \jsonSerializable
 
     /**
      * Serialize ProductInstancevalues to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductProperty.php
+++ b/lib/Model/ProductProperty.php
@@ -101,10 +101,8 @@ class ProductProperty implements \jsonSerializable
 
     /**
      * Serialize ProductProperty to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->name)) {
             $result["name"] = strval($this->name);

--- a/lib/Model/ProductProperty.php
+++ b/lib/Model/ProductProperty.php
@@ -101,6 +101,8 @@ class ProductProperty implements \jsonSerializable
 
     /**
      * Serialize ProductProperty to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductQuery.php
+++ b/lib/Model/ProductQuery.php
@@ -107,10 +107,8 @@ class ProductQuery implements \jsonSerializable
 
     /**
      * Serialize ProductQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/ProductQuery.php
+++ b/lib/Model/ProductQuery.php
@@ -107,6 +107,8 @@ class ProductQuery implements \jsonSerializable
 
     /**
      * Serialize ProductQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ProductVoucherValue.php
+++ b/lib/Model/ProductVoucherValue.php
@@ -85,10 +85,8 @@ class ProductVoucherValue implements \jsonSerializable
 
     /**
      * Serialize ProductVoucherValue to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/ProductVoucherValue.php
+++ b/lib/Model/ProductVoucherValue.php
@@ -85,6 +85,8 @@ class ProductVoucherValue implements \jsonSerializable
 
     /**
      * Serialize ProductVoucherValue to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PurgeOrdersRequest.php
+++ b/lib/Model/PurgeOrdersRequest.php
@@ -93,6 +93,8 @@ class PurgeOrdersRequest implements \jsonSerializable
 
     /**
      * Serialize PurgeOrdersRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/PurgeOrdersRequest.php
+++ b/lib/Model/PurgeOrdersRequest.php
@@ -93,10 +93,8 @@ class PurgeOrdersRequest implements \jsonSerializable
 
     /**
      * Serialize PurgeOrdersRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->contacts)) {
             $result["contacts"] = (bool)$this->contacts;

--- a/lib/Model/QueryRequest.php
+++ b/lib/Model/QueryRequest.php
@@ -93,6 +93,8 @@ class QueryRequest implements \jsonSerializable
 
     /**
      * Serialize QueryRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/QueryRequest.php
+++ b/lib/Model/QueryRequest.php
@@ -93,10 +93,8 @@ class QueryRequest implements \jsonSerializable
 
     /**
      * Serialize QueryRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->limit)) {
             $result["limit"] = intval($this->limit);

--- a/lib/Model/QueryResult.php
+++ b/lib/Model/QueryResult.php
@@ -85,10 +85,8 @@ class QueryResult implements \jsonSerializable
 
     /**
      * Serialize QueryResult to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->nbrofresults)) {
             $result["nbrofresults"] = intval($this->nbrofresults);

--- a/lib/Model/QueryResult.php
+++ b/lib/Model/QueryResult.php
@@ -85,6 +85,8 @@ class QueryResult implements \jsonSerializable
 
     /**
      * Serialize QueryResult to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/RelationType.php
+++ b/lib/Model/RelationType.php
@@ -136,10 +136,8 @@ class RelationType implements \jsonSerializable
 
     /**
      * Serialize RelationType to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/RelationType.php
+++ b/lib/Model/RelationType.php
@@ -136,6 +136,8 @@ class RelationType implements \jsonSerializable
 
     /**
      * Serialize RelationType to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/RelationTypeQuery.php
+++ b/lib/Model/RelationTypeQuery.php
@@ -99,10 +99,8 @@ class RelationTypeQuery implements \jsonSerializable
 
     /**
      * Serialize RelationTypeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/RelationTypeQuery.php
+++ b/lib/Model/RelationTypeQuery.php
@@ -99,6 +99,8 @@ class RelationTypeQuery implements \jsonSerializable
 
     /**
      * Serialize RelationTypeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Report.php
+++ b/lib/Model/Report.php
@@ -258,6 +258,8 @@ class Report implements \jsonSerializable
 
     /**
      * Serialize Report to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Report.php
+++ b/lib/Model/Report.php
@@ -258,10 +258,8 @@ class Report implements \jsonSerializable
 
     /**
      * Serialize Report to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ReportOptions.php
+++ b/lib/Model/ReportOptions.php
@@ -101,6 +101,8 @@ class ReportOptions implements \jsonSerializable
 
     /**
      * Serialize ReportOptions to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ReportOptions.php
+++ b/lib/Model/ReportOptions.php
@@ -101,10 +101,8 @@ class ReportOptions implements \jsonSerializable
 
     /**
      * Serialize ReportOptions to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->excelpagewidth)) {
             $result["excelpagewidth"] = intval($this->excelpagewidth);

--- a/lib/Model/ReportQuery.php
+++ b/lib/Model/ReportQuery.php
@@ -91,6 +91,8 @@ class ReportQuery implements \jsonSerializable
 
     /**
      * Serialize ReportQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ReportQuery.php
+++ b/lib/Model/ReportQuery.php
@@ -91,10 +91,8 @@ class ReportQuery implements \jsonSerializable
 
     /**
      * Serialize ReportQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/SalesChannel.php
+++ b/lib/Model/SalesChannel.php
@@ -155,6 +155,8 @@ class SalesChannel implements \jsonSerializable
 
     /**
      * Serialize SalesChannel to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SalesChannel.php
+++ b/lib/Model/SalesChannel.php
@@ -155,10 +155,8 @@ class SalesChannel implements \jsonSerializable
 
     /**
      * Serialize SalesChannel to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/SalesChannelQuery.php
+++ b/lib/Model/SalesChannelQuery.php
@@ -99,10 +99,8 @@ class SalesChannelQuery implements \jsonSerializable
 
     /**
      * Serialize SalesChannelQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/SalesChannelQuery.php
+++ b/lib/Model/SalesChannelQuery.php
@@ -99,6 +99,8 @@ class SalesChannelQuery implements \jsonSerializable
 
     /**
      * Serialize SalesChannelQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SeatDescriptionTemplate.php
+++ b/lib/Model/SeatDescriptionTemplate.php
@@ -93,10 +93,8 @@ class SeatDescriptionTemplate implements \jsonSerializable
 
     /**
      * Serialize SeatDescriptionTemplate to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/SeatDescriptionTemplate.php
+++ b/lib/Model/SeatDescriptionTemplate.php
@@ -93,6 +93,8 @@ class SeatDescriptionTemplate implements \jsonSerializable
 
     /**
      * Serialize SeatDescriptionTemplate to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SeatRank.php
+++ b/lib/Model/SeatRank.php
@@ -146,6 +146,8 @@ class SeatRank implements \jsonSerializable
 
     /**
      * Serialize SeatRank to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SeatRank.php
+++ b/lib/Model/SeatRank.php
@@ -146,10 +146,8 @@ class SeatRank implements \jsonSerializable
 
     /**
      * Serialize SeatRank to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/SeatRankQuery.php
+++ b/lib/Model/SeatRankQuery.php
@@ -99,6 +99,8 @@ class SeatRankQuery implements \jsonSerializable
 
     /**
      * Serialize SeatRankQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SeatRankQuery.php
+++ b/lib/Model/SeatRankQuery.php
@@ -99,10 +99,8 @@ class SeatRankQuery implements \jsonSerializable
 
     /**
      * Serialize SeatRankQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/SeatingPlan.php
+++ b/lib/Model/SeatingPlan.php
@@ -168,6 +168,8 @@ class SeatingPlan implements \jsonSerializable
 
     /**
      * Serialize SeatingPlan to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SeatingPlan.php
+++ b/lib/Model/SeatingPlan.php
@@ -168,10 +168,8 @@ class SeatingPlan implements \jsonSerializable
 
     /**
      * Serialize SeatingPlan to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/SeatingPlanQuery.php
+++ b/lib/Model/SeatingPlanQuery.php
@@ -99,6 +99,8 @@ class SeatingPlanQuery implements \jsonSerializable
 
     /**
      * Serialize SeatingPlanQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SeatingPlanQuery.php
+++ b/lib/Model/SeatingPlanQuery.php
@@ -99,10 +99,8 @@ class SeatingPlanQuery implements \jsonSerializable
 
     /**
      * Serialize SeatingPlanQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/ServicemailScheduling.php
+++ b/lib/Model/ServicemailScheduling.php
@@ -94,9 +94,9 @@ class ServicemailScheduling implements \jsonSerializable
     /**
      * Serialize ServicemailScheduling to JSON.
      *
-     * @return array
+     * @return mixed
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->days)) {
             $result["days"] = intval($this->days);

--- a/lib/Model/SetOrderCost.php
+++ b/lib/Model/SetOrderCost.php
@@ -85,10 +85,8 @@ class SetOrderCost implements \jsonSerializable
 
     /**
      * Serialize SetOrderCost to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->amount)) {
             $result["amount"] = floatval($this->amount);

--- a/lib/Model/SetOrderCost.php
+++ b/lib/Model/SetOrderCost.php
@@ -85,6 +85,8 @@ class SetOrderCost implements \jsonSerializable
 
     /**
      * Serialize SetOrderCost to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SplitOrder.php
+++ b/lib/Model/SplitOrder.php
@@ -120,10 +120,8 @@ class SplitOrder implements \jsonSerializable
 
     /**
      * Serialize SplitOrder to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->customerid)) {
             $result["customerid"] = intval($this->customerid);

--- a/lib/Model/SplitOrder.php
+++ b/lib/Model/SplitOrder.php
@@ -120,6 +120,8 @@ class SplitOrder implements \jsonSerializable
 
     /**
      * Serialize SplitOrder to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SubscriberCommunication.php
+++ b/lib/Model/SubscriberCommunication.php
@@ -101,6 +101,8 @@ class SubscriberCommunication implements \jsonSerializable
 
     /**
      * Serialize SubscriberCommunication to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SubscriberCommunication.php
+++ b/lib/Model/SubscriberCommunication.php
@@ -101,10 +101,8 @@ class SubscriberCommunication implements \jsonSerializable
 
     /**
      * Serialize SubscriberCommunication to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->name)) {
             $result["name"] = strval($this->name);

--- a/lib/Model/SubscriberSync.php
+++ b/lib/Model/SubscriberSync.php
@@ -112,6 +112,8 @@ class SubscriberSync implements \jsonSerializable
 
     /**
      * Serialize SubscriberSync to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/SubscriberSync.php
+++ b/lib/Model/SubscriberSync.php
@@ -112,10 +112,8 @@ class SubscriberSync implements \jsonSerializable
 
     /**
      * Serialize SubscriberSync to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->email)) {
             $result["email"] = strval($this->email);

--- a/lib/Model/TicketFee.php
+++ b/lib/Model/TicketFee.php
@@ -138,10 +138,8 @@ class TicketFee implements \jsonSerializable
 
     /**
      * Serialize TicketFee to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/TicketFee.php
+++ b/lib/Model/TicketFee.php
@@ -138,6 +138,8 @@ class TicketFee implements \jsonSerializable
 
     /**
      * Serialize TicketFee to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketFeeQuery.php
+++ b/lib/Model/TicketFeeQuery.php
@@ -99,10 +99,8 @@ class TicketFeeQuery implements \jsonSerializable
 
     /**
      * Serialize TicketFeeQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/TicketFeeQuery.php
+++ b/lib/Model/TicketFeeQuery.php
@@ -99,6 +99,8 @@ class TicketFeeQuery implements \jsonSerializable
 
     /**
      * Serialize TicketFeeQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketLayout.php
+++ b/lib/Model/TicketLayout.php
@@ -139,6 +139,8 @@ class TicketLayout implements \jsonSerializable
 
     /**
      * Serialize TicketLayout to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketLayout.php
+++ b/lib/Model/TicketLayout.php
@@ -139,10 +139,8 @@ class TicketLayout implements \jsonSerializable
 
     /**
      * Serialize TicketLayout to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/TicketLayoutQuery.php
+++ b/lib/Model/TicketLayoutQuery.php
@@ -107,10 +107,8 @@ class TicketLayoutQuery implements \jsonSerializable
 
     /**
      * Serialize TicketLayoutQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/TicketLayoutQuery.php
+++ b/lib/Model/TicketLayoutQuery.php
@@ -107,6 +107,8 @@ class TicketLayoutQuery implements \jsonSerializable
 
     /**
      * Serialize TicketLayoutQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketLayoutTemplate.php
+++ b/lib/Model/TicketLayoutTemplate.php
@@ -186,10 +186,8 @@ class TicketLayoutTemplate implements \jsonSerializable
 
     /**
      * Serialize TicketLayoutTemplate to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/TicketLayoutTemplate.php
+++ b/lib/Model/TicketLayoutTemplate.php
@@ -186,6 +186,8 @@ class TicketLayoutTemplate implements \jsonSerializable
 
     /**
      * Serialize TicketLayoutTemplate to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketLayoutTemplateQuery.php
+++ b/lib/Model/TicketLayoutTemplateQuery.php
@@ -109,10 +109,8 @@ class TicketLayoutTemplateQuery implements \jsonSerializable
 
     /**
      * Serialize TicketLayoutTemplateQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/TicketLayoutTemplateQuery.php
+++ b/lib/Model/TicketLayoutTemplateQuery.php
@@ -109,6 +109,8 @@ class TicketLayoutTemplateQuery implements \jsonSerializable
 
     /**
      * Serialize TicketLayoutTemplateQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketfeeException.php
+++ b/lib/Model/TicketfeeException.php
@@ -86,6 +86,8 @@ class TicketfeeException implements \jsonSerializable
 
     /**
      * Serialize TicketfeeException to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketfeeException.php
+++ b/lib/Model/TicketfeeException.php
@@ -86,10 +86,8 @@ class TicketfeeException implements \jsonSerializable
 
     /**
      * Serialize TicketfeeException to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->pricetypeid)) {
             $result["pricetypeid"] = intval($this->pricetypeid);

--- a/lib/Model/TicketfeeRules.php
+++ b/lib/Model/TicketfeeRules.php
@@ -87,6 +87,8 @@ class TicketfeeRules implements \jsonSerializable
 
     /**
      * Serialize TicketfeeRules to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketfeeRules.php
+++ b/lib/Model/TicketfeeRules.php
@@ -87,10 +87,8 @@ class TicketfeeRules implements \jsonSerializable
 
     /**
      * Serialize TicketfeeRules to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->default)) {
             $result["default"] = $this->default;

--- a/lib/Model/TicketfeeSaleschannelRule.php
+++ b/lib/Model/TicketfeeSaleschannelRule.php
@@ -99,6 +99,8 @@ class TicketfeeSaleschannelRule implements \jsonSerializable
 
     /**
      * Serialize TicketfeeSaleschannelRule to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketfeeSaleschannelRule.php
+++ b/lib/Model/TicketfeeSaleschannelRule.php
@@ -99,10 +99,8 @@ class TicketfeeSaleschannelRule implements \jsonSerializable
 
     /**
      * Serialize TicketfeeSaleschannelRule to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->saleschannelid)) {
             $result["saleschannelid"] = intval($this->saleschannelid);

--- a/lib/Model/TicketsEmaildeliveryRequest.php
+++ b/lib/Model/TicketsEmaildeliveryRequest.php
@@ -77,10 +77,8 @@ class TicketsEmaildeliveryRequest implements \jsonSerializable
 
     /**
      * Serialize TicketsEmaildeliveryRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->templateid)) {
             $result["templateid"] = intval($this->templateid);

--- a/lib/Model/TicketsEmaildeliveryRequest.php
+++ b/lib/Model/TicketsEmaildeliveryRequest.php
@@ -77,6 +77,8 @@ class TicketsEmaildeliveryRequest implements \jsonSerializable
 
     /**
      * Serialize TicketsEmaildeliveryRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsPdfRequest.php
+++ b/lib/Model/TicketsPdfRequest.php
@@ -86,10 +86,8 @@ class TicketsPdfRequest implements \jsonSerializable
 
     /**
      * Serialize TicketsPdfRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->tickets)) {
             $result["tickets"] = $this->tickets;

--- a/lib/Model/TicketsPdfRequest.php
+++ b/lib/Model/TicketsPdfRequest.php
@@ -86,6 +86,8 @@ class TicketsPdfRequest implements \jsonSerializable
 
     /**
      * Serialize TicketsPdfRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsalesFlowConfig.php
+++ b/lib/Model/TicketsalesFlowConfig.php
@@ -101,10 +101,8 @@ class TicketsalesFlowConfig implements \jsonSerializable
 
     /**
      * Serialize TicketsalesFlowConfig to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->from)) {
             $result["from"] = Json::packTimestamp($this->from);

--- a/lib/Model/TicketsalesFlowConfig.php
+++ b/lib/Model/TicketsalesFlowConfig.php
@@ -101,6 +101,8 @@ class TicketsalesFlowConfig implements \jsonSerializable
 
     /**
      * Serialize TicketsalesFlowConfig to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Ticketsalesflow.php
+++ b/lib/Model/Ticketsalesflow.php
@@ -157,10 +157,8 @@ class Ticketsalesflow implements \jsonSerializable
 
     /**
      * Serialize Ticketsalesflow to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Ticketsalesflow.php
+++ b/lib/Model/Ticketsalesflow.php
@@ -157,6 +157,8 @@ class Ticketsalesflow implements \jsonSerializable
 
     /**
      * Serialize Ticketsalesflow to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsalesflowQuery.php
+++ b/lib/Model/TicketsalesflowQuery.php
@@ -91,10 +91,8 @@ class TicketsalesflowQuery implements \jsonSerializable
 
     /**
      * Serialize TicketsalesflowQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/TicketsalesflowQuery.php
+++ b/lib/Model/TicketsalesflowQuery.php
@@ -91,6 +91,8 @@ class TicketsalesflowQuery implements \jsonSerializable
 
     /**
      * Serialize TicketsalesflowQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Ticketsalessetup.php
+++ b/lib/Model/Ticketsalessetup.php
@@ -116,10 +116,8 @@ class Ticketsalessetup implements \jsonSerializable
 
     /**
      * Serialize Ticketsalessetup to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Ticketsalessetup.php
+++ b/lib/Model/Ticketsalessetup.php
@@ -116,6 +116,8 @@ class Ticketsalessetup implements \jsonSerializable
 
     /**
      * Serialize Ticketsalessetup to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsalessetupQuery.php
+++ b/lib/Model/TicketsalessetupQuery.php
@@ -91,10 +91,8 @@ class TicketsalessetupQuery implements \jsonSerializable
 
     /**
      * Serialize TicketsalessetupQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/TicketsalessetupQuery.php
+++ b/lib/Model/TicketsalessetupQuery.php
@@ -91,6 +91,8 @@ class TicketsalessetupQuery implements \jsonSerializable
 
     /**
      * Serialize TicketsalessetupQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsprocessedRequest.php
+++ b/lib/Model/TicketsprocessedRequest.php
@@ -93,6 +93,8 @@ class TicketsprocessedRequest implements \jsonSerializable
 
     /**
      * Serialize TicketsprocessedRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsprocessedRequest.php
+++ b/lib/Model/TicketsprocessedRequest.php
@@ -93,10 +93,8 @@ class TicketsprocessedRequest implements \jsonSerializable
 
     /**
      * Serialize TicketsprocessedRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->endts)) {
             $result["endts"] = strval($this->endts);

--- a/lib/Model/TicketsprocessedStatistics.php
+++ b/lib/Model/TicketsprocessedStatistics.php
@@ -93,6 +93,8 @@ class TicketsprocessedStatistics implements \jsonSerializable
 
     /**
      * Serialize TicketsprocessedStatistics to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/TicketsprocessedStatistics.php
+++ b/lib/Model/TicketsprocessedStatistics.php
@@ -93,10 +93,8 @@ class TicketsprocessedStatistics implements \jsonSerializable
 
     /**
      * Serialize TicketsprocessedStatistics to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->processed)) {
             $result["processed"] = intval($this->processed);

--- a/lib/Model/Timestamp.php
+++ b/lib/Model/Timestamp.php
@@ -77,10 +77,8 @@ class Timestamp implements \jsonSerializable
 
     /**
      * Serialize Timestamp to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->systemtime)) {
             $result["systemtime"] = Json::packTimestamp($this->systemtime);

--- a/lib/Model/Timestamp.php
+++ b/lib/Model/Timestamp.php
@@ -77,6 +77,8 @@ class Timestamp implements \jsonSerializable
 
     /**
      * Serialize Timestamp to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/UpdateOrder.php
+++ b/lib/Model/UpdateOrder.php
@@ -135,6 +135,8 @@ class UpdateOrder implements \jsonSerializable
 
     /**
      * Serialize UpdateOrder to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/UpdateOrder.php
+++ b/lib/Model/UpdateOrder.php
@@ -135,10 +135,8 @@ class UpdateOrder implements \jsonSerializable
 
     /**
      * Serialize UpdateOrder to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->customerid)) {
             $result["customerid"] = intval($this->customerid);

--- a/lib/Model/UpdateProducts.php
+++ b/lib/Model/UpdateProducts.php
@@ -103,10 +103,8 @@ class UpdateProducts implements \jsonSerializable
 
     /**
      * Serialize UpdateProducts to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->operation)) {
             $result["operation"] = strval($this->operation);

--- a/lib/Model/UpdateProducts.php
+++ b/lib/Model/UpdateProducts.php
@@ -103,6 +103,8 @@ class UpdateProducts implements \jsonSerializable
 
     /**
      * Serialize UpdateProducts to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/UpdateTickets.php
+++ b/lib/Model/UpdateTickets.php
@@ -116,6 +116,8 @@ class UpdateTickets implements \jsonSerializable
 
     /**
      * Serialize UpdateTickets to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/UpdateTickets.php
+++ b/lib/Model/UpdateTickets.php
@@ -116,10 +116,8 @@ class UpdateTickets implements \jsonSerializable
 
     /**
      * Serialize UpdateTickets to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->operation)) {
             $result["operation"] = strval($this->operation);

--- a/lib/Model/Url.php
+++ b/lib/Model/Url.php
@@ -77,6 +77,8 @@ class Url implements \jsonSerializable
 
     /**
      * Serialize Url to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/Url.php
+++ b/lib/Model/Url.php
@@ -77,10 +77,8 @@ class Url implements \jsonSerializable
 
     /**
      * Serialize Url to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->url)) {
             $result["url"] = strval($this->url);

--- a/lib/Model/View.php
+++ b/lib/Model/View.php
@@ -162,10 +162,8 @@ class View implements \jsonSerializable
 
     /**
      * Serialize View to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/View.php
+++ b/lib/Model/View.php
@@ -162,6 +162,8 @@ class View implements \jsonSerializable
 
     /**
      * Serialize View to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ViewColumn.php
+++ b/lib/Model/ViewColumn.php
@@ -77,10 +77,8 @@ class ViewColumn implements \jsonSerializable
 
     /**
      * Serialize ViewColumn to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/ViewColumn.php
+++ b/lib/Model/ViewColumn.php
@@ -77,6 +77,8 @@ class ViewColumn implements \jsonSerializable
 
     /**
      * Serialize ViewColumn to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ViewQuery.php
+++ b/lib/Model/ViewQuery.php
@@ -107,6 +107,8 @@ class ViewQuery implements \jsonSerializable
 
     /**
      * Serialize ViewQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/ViewQuery.php
+++ b/lib/Model/ViewQuery.php
@@ -107,10 +107,8 @@ class ViewQuery implements \jsonSerializable
 
     /**
      * Serialize ViewQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/Voucher.php
+++ b/lib/Model/Voucher.php
@@ -219,10 +219,8 @@ class Voucher implements \jsonSerializable
 
     /**
      * Serialize Voucher to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/Voucher.php
+++ b/lib/Model/Voucher.php
@@ -219,6 +219,8 @@ class Voucher implements \jsonSerializable
 
     /**
      * Serialize Voucher to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/VoucherCode.php
+++ b/lib/Model/VoucherCode.php
@@ -85,10 +85,8 @@ class VoucherCode implements \jsonSerializable
 
     /**
      * Serialize VoucherCode to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->code)) {
             $result["code"] = strval($this->code);

--- a/lib/Model/VoucherCode.php
+++ b/lib/Model/VoucherCode.php
@@ -85,6 +85,8 @@ class VoucherCode implements \jsonSerializable
 
     /**
      * Serialize VoucherCode to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/VoucherQuery.php
+++ b/lib/Model/VoucherQuery.php
@@ -107,6 +107,8 @@ class VoucherQuery implements \jsonSerializable
 
     /**
      * Serialize VoucherQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/VoucherQuery.php
+++ b/lib/Model/VoucherQuery.php
@@ -107,10 +107,8 @@ class VoucherQuery implements \jsonSerializable
 
     /**
      * Serialize VoucherQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->typeid)) {
             $result["typeid"] = intval($this->typeid);

--- a/lib/Model/VoucherValidity.php
+++ b/lib/Model/VoucherValidity.php
@@ -107,10 +107,8 @@ class VoucherValidity implements \jsonSerializable
 
     /**
      * Serialize VoucherValidity to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->expiry_fixeddate)) {
             $result["expiry_fixeddate"] = Json::packTimestamp($this->expiry_fixeddate);

--- a/lib/Model/VoucherValidity.php
+++ b/lib/Model/VoucherValidity.php
@@ -107,6 +107,8 @@ class VoucherValidity implements \jsonSerializable
 
     /**
      * Serialize VoucherValidity to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WaitingListRequest.php
+++ b/lib/Model/WaitingListRequest.php
@@ -200,10 +200,8 @@ class WaitingListRequest implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequest to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/WaitingListRequest.php
+++ b/lib/Model/WaitingListRequest.php
@@ -200,6 +200,8 @@ class WaitingListRequest implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequest to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WaitingListRequestItem.php
+++ b/lib/Model/WaitingListRequestItem.php
@@ -103,10 +103,8 @@ class WaitingListRequestItem implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequestItem to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->eventid)) {
             $result["eventid"] = intval($this->eventid);

--- a/lib/Model/WaitingListRequestItem.php
+++ b/lib/Model/WaitingListRequestItem.php
@@ -103,6 +103,8 @@ class WaitingListRequestItem implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequestItem to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WaitingListRequestItemTicket.php
+++ b/lib/Model/WaitingListRequestItemTicket.php
@@ -77,6 +77,8 @@ class WaitingListRequestItemTicket implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequestItemTicket to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WaitingListRequestItemTicket.php
+++ b/lib/Model/WaitingListRequestItemTicket.php
@@ -77,10 +77,8 @@ class WaitingListRequestItemTicket implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequestItemTicket to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->tickettypepriceid)) {
             $result["tickettypepriceid"] = intval($this->tickettypepriceid);

--- a/lib/Model/WaitingListRequestQuery.php
+++ b/lib/Model/WaitingListRequestQuery.php
@@ -99,6 +99,8 @@ class WaitingListRequestQuery implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequestQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WaitingListRequestQuery.php
+++ b/lib/Model/WaitingListRequestQuery.php
@@ -99,10 +99,8 @@ class WaitingListRequestQuery implements \jsonSerializable
 
     /**
      * Serialize WaitingListRequestQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);

--- a/lib/Model/WebSalesSkin.php
+++ b/lib/Model/WebSalesSkin.php
@@ -177,10 +177,8 @@ class WebSalesSkin implements \jsonSerializable
 
     /**
      * Serialize WebSalesSkin to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->id)) {
             $result["id"] = intval($this->id);

--- a/lib/Model/WebSalesSkin.php
+++ b/lib/Model/WebSalesSkin.php
@@ -177,6 +177,8 @@ class WebSalesSkin implements \jsonSerializable
 
     /**
      * Serialize WebSalesSkin to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WebSalesSkinConfiguration.php
+++ b/lib/Model/WebSalesSkinConfiguration.php
@@ -110,6 +110,8 @@ class WebSalesSkinConfiguration implements \jsonSerializable
 
     /**
      * Serialize WebSalesSkinConfiguration to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WebSalesSkinConfiguration.php
+++ b/lib/Model/WebSalesSkinConfiguration.php
@@ -110,10 +110,8 @@ class WebSalesSkinConfiguration implements \jsonSerializable
 
     /**
      * Serialize WebSalesSkinConfiguration to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->favicon)) {
             $result["favicon"] = strval($this->favicon);

--- a/lib/Model/WebSalesSkinQuery.php
+++ b/lib/Model/WebSalesSkinQuery.php
@@ -91,6 +91,8 @@ class WebSalesSkinQuery implements \jsonSerializable
 
     /**
      * Serialize WebSalesSkinQuery to JSON.
+     *
+     * @return mixed
      */
     public function jsonSerialize(): mixed {
         $result = array();

--- a/lib/Model/WebSalesSkinQuery.php
+++ b/lib/Model/WebSalesSkinQuery.php
@@ -91,10 +91,8 @@ class WebSalesSkinQuery implements \jsonSerializable
 
     /**
      * Serialize WebSalesSkinQuery to JSON.
-     *
-     * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize(): mixed {
         $result = array();
         if (!is_null($this->filter)) {
             $result["filter"] = strval($this->filter);


### PR DESCRIPTION
I changed the return types to mixed for all jsonSerialize functions, including in the docs block.